### PR TITLE
remove new issue label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -6,7 +6,6 @@ labels: "bug"
 assignees: ""
 ---
 
-<!--- Please DO NOT remove the automatically added 'new issue' label -->
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Expected Behavior

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -2,9 +2,8 @@
 name: Custom Template
 about: Create a custom issue
 title: ""
-labels: "new issue"
+labels: ""
 assignees: ""
 ---
 
-<!--- Please DO NOT remove the automatically added 'new issue' label -->
 <!--- Provide a general summary of the issue in the Title above -->

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -2,11 +2,10 @@
 name: Enhancement Template
 about: Create a enhancement request
 title: ""
-labels: "enhancement, new issue"
+labels: "enhancement"
 assignees: ""
 ---
 
-<!--- Please DO NOT remove the automatically added 'new issue' label -->
 <!--- Provide a general summary of the issue in the Title above -->
 
 ### Is your feature related to a problem?

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -6,7 +6,7 @@ labels: "epic"
 assignees: ""
 ---
 
-<!--- Please DO NOT remove the automatically added 'new issue' label -->
+<!--- Please DO NOT remove the automatically added 'epic' label -->
 <!--- Provide a general summary of the issue in the Title above -->
 
 <!--


### PR DESCRIPTION
Related #20 

Removes mentions of "new issue" and renames feature template to something more consistent with our label