### PR TITLE
Hotfix stop sandbox

### DIFF
--- a/devkit/sandbox/src/common.sh
+++ b/devkit/sandbox/src/common.sh
@@ -5,8 +5,9 @@ DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)
 
 # stop sandbox
 stop() {
-    docker-compose --file $DIR/nodes-docker-compose.yml down;
-    docker-compose --file $DIR/central-docker-compose.yml down;
+    echo "$DIR"
+    docker-compose -p sandbox-nodes down;
+    docker-compose -p sandbox-central down;
     exit;
 }
 

--- a/devkit/sandbox/src/common.sh
+++ b/devkit/sandbox/src/common.sh
@@ -5,7 +5,6 @@ DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)
 
 # stop sandbox
 stop() {
-    echo "$DIR"
     docker-compose -p sandbox-nodes down;
     docker-compose -p sandbox-central down;
     exit;


### PR DESCRIPTION
As sandbox is created with a project name, to stop it, we have to refer to the project names assigned to the docker compose.