### PR TITLE
add api version to DP

### DIFF
--- a/apps/discovery-platform/src/entry-server/index.spec.ts
+++ b/apps/discovery-platform/src/entry-server/index.spec.ts
@@ -1,20 +1,20 @@
-import assert from "assert";
-import { DBInstance } from "../db";
-import request from "supertest";
 import { Express } from "express";
-import { doesClientHaveQuota, entryServer } from ".";
-import {
-  CreateRegisteredNode,
-  QueryRegisteredNode,
-} from "../registered-node/dto";
+import { entryServer } from ".";
+import { DBInstance } from "../db";
+import nock from "nock";
+import { MockPgInstanceSingleton } from "../db/index.spec";
 import { FundingServiceApi } from "../funding-service-api";
 import * as registeredNode from "../registered-node";
-import nock from "nock";
 import {
   getAccessTokenResponse,
   postFundingResponse,
 } from "../funding-service-api/dto";
-import { MockPgInstanceSingleton } from "../db/index.spec";
+import request from "supertest";
+import {
+  CreateRegisteredNode,
+  QueryRegisteredNode,
+} from "../registered-node/dto";
+import assert from "assert";
 
 const FUNDING_SERVICE_URL = "http://localhost:5000";
 const ACCESS_TOKEN = "ACCESS";
@@ -66,189 +66,48 @@ describe("test entry server", function () {
     jest.resetAllMocks();
   });
 
-  it("should register a node", async function () {
-    const node = mockNode();
-    await request(app).post("/api/node/register").send(node);
-    const createdNode = await request(app).get(`/api/node/${node.peerId}`);
-    assert.equal(createdNode.body.node.id, node.peerId);
-  });
+  it("should retrieve an entry node", async function () {
+    const spy = jest.spyOn(registeredNode, "getEligibleNode");
+    const amountLeft = 10;
+    const peerId = "entry";
+    const requestId = 1;
 
-  it("should get a node", async function () {
-    const node = mockNode();
-    await request(app).post("/api/node/register").send(node);
-    await request(app).post("/api/node/register").send(mockNode("fake"));
-    const createdNode = await request(app).get(`/api/node/${node.peerId}`);
-    assert.equal(createdNode.body.node.id, node.peerId);
-  });
+    nockGetApiAccessToken.reply(200, {
+      accessToken: FAKE_ACCESS_TOKEN,
+      amountLeft: 10,
+      expiredAt: new Date().toISOString(),
+    } as getAccessTokenResponse);
 
-  it("should get all nodes", async function () {
+    await request(app).post("/api/v1/client/funds").send({
+      client: "client",
+      quota: 1,
+    });
+
     await request(app)
-      .post("/api/node/register")
-      .send(mockNode("notExit1", false));
-    await request(app)
-      .post("/api/node/register")
-      .send(mockNode("notExit2", false));
-    await request(app).post("/api/node/register").send(mockNode("exit3", true));
-    await request(app).post("/api/node/register").send(mockNode("exit4", true));
+      .post("/api/v1/node/register")
+      .send(mockNode(peerId, true));
 
-    const allExitNodes = await request(app).get(
-      `/api/node?hasExitNode=${false}`
-    );
+    const createdNode = (await request(app).get(`/api/v1/node/${peerId}`)) as {
+      body: { node: QueryRegisteredNode | undefined };
+    };
 
-    assert(typeof allExitNodes.body === "object" && allExitNodes.body.length);
-  });
-
-  it("should add quota to a client", async function () {
-    const createdQuota = await request(app).post("/api/client/funds").send({
-      client: "client",
-      quota: 1,
+    spy.mockImplementation(async () => {
+      return createdNode.body.node;
     });
-    assert.equal(createdQuota.body.quota.quota, 1);
-  });
 
-  it.skip("should not allow request client does not have enough quota", async function () {
-    // create quota for client
-    await request(app).post("/api/client/funds").send({
-      client: "client",
-      quota: 1,
-    });
-    const doesClientHaveQuotaResponse = await doesClientHaveQuota(
-      dbInstance,
-      "client",
-      2
-    );
+    nockFundingRequest(createdNode.body.node?.native_address!).reply(200, {
+      amountLeft,
+      id: requestId,
+    } as postFundingResponse);
 
-    assert(!doesClientHaveQuotaResponse);
-  });
-  it("should allow request because client has enough quota", async function () {
-    // create quota for wrong client
-    await request(app).post("/api/client/funds").send({
-      client: "client",
-      quota: 1,
-    });
-    const doesClientHaveQuotaResponse = await doesClientHaveQuota(
-      dbInstance,
-      "client",
-      1
-    );
+    const requestResponse = await request(app)
+      .post("/api/v1/request/entry-node")
+      .send({ client: "client" });
 
-    assert(doesClientHaveQuotaResponse);
-  });
-  describe("should select an entry node", function () {
-    it("should return an entry node", async function () {
-      const spy = jest.spyOn(registeredNode, "getEligibleNode");
-      const amountLeft = 10;
-      const peerId = "entry";
-      const requestId = 1;
+    if (!requestResponse.body || !createdNode.body.node)
+      throw new Error("Could not create mock nodes");
 
-      nockGetApiAccessToken.reply(200, {
-        accessToken: FAKE_ACCESS_TOKEN,
-        amountLeft: 10,
-        expiredAt: new Date().toISOString(),
-      } as getAccessTokenResponse);
-
-      await request(app).post("/api/client/funds").send({
-        client: "client",
-        quota: 1,
-      });
-
-      await request(app)
-        .post("/api/node/register")
-        .send(mockNode(peerId, true));
-
-      const createdNode = (await request(app).get(`/api/node/${peerId}`)) as {
-        body: { node: QueryRegisteredNode | undefined };
-      };
-
-      spy.mockImplementation(async () => {
-        return createdNode.body.node;
-      });
-
-      nockFundingRequest(createdNode.body.node?.native_address!).reply(200, {
-        amountLeft,
-        id: requestId,
-      } as postFundingResponse);
-
-      const requestResponse = await request(app)
-        .post("/api/request/entry-node")
-        .send({ client: "client" });
-
-      assert.equal(requestResponse.body.id, createdNode.body.node?.id);
-      spy.mockRestore();
-    });
-    it("should fail if no entry node is selected", async function () {
-      const spy = jest.spyOn(registeredNode, "getEligibleNode");
-      const amountLeft = 10;
-      const peerId = "entry";
-      const requestId = 1;
-
-      nockGetApiAccessToken.reply(200, {
-        accessToken: FAKE_ACCESS_TOKEN,
-        amountLeft: 10,
-        expiredAt: new Date().toISOString(),
-      } as getAccessTokenResponse);
-
-      await request(app).post("/api/client/funds").send({
-        client: "client",
-        quota: 1,
-      });
-
-      spy.mockImplementation(async () => undefined);
-
-      const requestResponse = await request(app)
-        .post("/api/request/entry-node")
-        .send({ client: "client" });
-
-      assert.equal(requestResponse.body.body, "Could not find eligible node");
-      spy.mockRestore();
-    });
-    it.skip("should reduce client quota", async function () {
-      const spy = jest.spyOn(registeredNode, "getEligibleNode");
-      const amountLeft = 10;
-      const peerId = "entry";
-      const requestId = 1;
-
-      nockGetApiAccessToken.reply(200, {
-        accessToken: FAKE_ACCESS_TOKEN,
-        amountLeft: 10,
-        expiredAt: new Date().toISOString(),
-      } as getAccessTokenResponse);
-
-      await request(app).post("/api/client/funds").send({
-        client: "newClient",
-        quota: BASE_QUOTA,
-      });
-
-      await request(app)
-        .post("/api/node/register")
-        .send(mockNode(peerId, true));
-
-      const createdNode = (await request(app).get(`/api/node/${peerId}`)) as {
-        body: { node: QueryRegisteredNode | undefined };
-      };
-
-      spy.mockImplementation(async () => {
-        return createdNode.body.node;
-      });
-
-      nockFundingRequest(createdNode.body.node?.native_address!).reply(200, {
-        amountLeft,
-        id: requestId,
-      } as postFundingResponse);
-
-      await request(app)
-        .post("/api/request/entry-node")
-        .send({ client: "newClient" });
-
-      const requestResponse = await request(app)
-        .post("/api/request/entry-node")
-        .send({ client: "newClient" });
-
-      assert.equal(
-        requestResponse.body.body,
-        "Client does not have enough quota"
-      );
-      spy.mockRestore();
-    });
+    assert.equal(requestResponse.body.id, createdNode.body.node.id);
+    spy.mockRestore();
   });
 });

--- a/apps/discovery-platform/src/entry-server/index.ts
+++ b/apps/discovery-platform/src/entry-server/index.ts
@@ -1,35 +1,9 @@
 import express from "express";
 import { DBInstance } from "../db";
 import { FundingServiceApi } from "../funding-service-api";
-import { createQuota, getAllQuotasByClient, sumQuotas } from "../quota";
-import { CreateQuota } from "../quota/dto";
-import {
-  createRegisteredNode,
-  getExitNodes,
-  getNonExitNodes,
-  getRegisteredNode,
-  getEligibleNode,
-  getRewardForNode,
-} from "../registered-node";
-import { CreateRegisteredNode } from "../registered-node/dto";
-import { createLogger } from "../utils";
+import { v1Router } from "./routers/v1";
 
 const app = express();
-const apiRouter = express.Router();
-const log = createLogger(["entry-server"]);
-
-// base amount of reward that a node will receive after completing a request
-const BASE_EXTRA = 1;
-
-export const doesClientHaveQuota = async (
-  db: DBInstance,
-  client: string,
-  baseQuota: number
-) => {
-  const allQuotasFromClient = await getAllQuotasByClient(db, client);
-  const sumOfClientsQuota = sumQuotas(allQuotasFromClient);
-  return sumOfClientsQuota >= baseQuota;
-};
 
 export const entryServer = (ops: {
   db: DBInstance;
@@ -37,88 +11,15 @@ export const entryServer = (ops: {
   accessToken: string;
   fundingServiceApi: FundingServiceApi;
 }) => {
-  app.use("/api", apiRouter);
-  apiRouter.use(express.json());
-
-  apiRouter.post("/node/register", async (req, res) => {
-    log.verbose("/node/register", req.body);
-    const node = req.body as CreateRegisteredNode;
-    const registered = await createRegisteredNode(ops.db, node);
-    return res.json({ body: registered });
-  });
-
-  apiRouter.get("/node", async (req, res) => {
-    const { hasExitNode } = req.query;
-    if (hasExitNode === "true") {
-      const nodes = await getExitNodes(ops.db);
-      return res.json(nodes);
-    } else {
-      const nodes = await getNonExitNodes(ops.db);
-      return res.json(nodes);
-    }
-  });
-
-  apiRouter.get("/node/:peerId", async (req, res) => {
-    const { peerId } = req.params;
-    const node = await getRegisteredNode(ops.db, peerId as string);
-    return res.json({ node });
-  });
-
-  apiRouter.get("/funding-service/funds", async (req, res) => {
-    const funds = await ops.fundingServiceApi.getAvailableFunds();
-    return res.json({ body: funds });
-  });
-
-  apiRouter.post("/client/funds", async (req, res) => {
-    const { client, quota } = req.body as CreateQuota;
-    const createdQuota = await createQuota(ops.db, {
-      client,
-      quota,
-      actionTaker: "discovery platform",
-    });
-    return res.json({ quota: createdQuota });
-  });
-
-  apiRouter.post("/request/entry-node", async (req, res) => {
-    const { client } = req.body;
-    log.verbose("requesting entry node for client", client);
-    if (typeof client !== "string") throw Error("Client is not a string");
-
-    // check if client has enough quota
-    const doesClientHaveQuotaResponse = await doesClientHaveQuota(
-      ops.db,
-      client,
-      ops.baseQuota
-    );
-    if (!doesClientHaveQuotaResponse) {
-      return res.status(400).json({
-        body: "Client does not have enough quota",
-      });
-    }
-    // choose selected entry node
-    const selectedNode = await getEligibleNode(ops.db);
-    log.verbose("selected entry node", selectedNode);
-    if (!selectedNode) {
-      return res.json({ body: "Could not find eligible node" });
-    }
-
-    // calculate how much should be funded to entry node
-    const amountToFund = getRewardForNode(
-      ops.baseQuota,
-      BASE_EXTRA,
-      selectedNode
-    );
-    // fund entry node
-    await ops.fundingServiceApi.requestFunds(amountToFund, selectedNode);
-
-    // create negative quota (showing that the client has used up initial quota)
-    await createQuota(ops.db, {
-      client,
-      quota: ops.baseQuota * -1,
-      actionTaker: "discovery platform",
-    });
-    return res.json({ ...selectedNode, accessToken: ops.accessToken });
-  });
+  app.use(
+    "/api/v1",
+    v1Router({
+      accessToken: ops.accessToken,
+      baseQuota: ops.baseQuota,
+      db: ops.db,
+      fundingServiceApi: ops.fundingServiceApi,
+    })
+  );
 
   return app;
 };

--- a/apps/discovery-platform/src/entry-server/routers/v1/index.spec.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/index.spec.ts
@@ -1,0 +1,247 @@
+import assert from "assert";
+import express, { Express } from "express";
+import nock from "nock";
+import request from "supertest";
+import { doesClientHaveQuota, v1Router } from ".";
+import { DBInstance } from "../../../db";
+import { MockPgInstanceSingleton } from "../../../db/index.spec";
+import { FundingServiceApi } from "../../../funding-service-api";
+import {
+  getAccessTokenResponse,
+  postFundingResponse,
+} from "../../../funding-service-api/dto";
+import * as registeredNode from "../../../registered-node";
+import {
+  CreateRegisteredNode,
+  QueryRegisteredNode,
+} from "../../../registered-node/dto";
+
+const FUNDING_SERVICE_URL = "http://localhost:5000";
+const ACCESS_TOKEN = "ACCESS";
+const BASE_QUOTA = 1;
+const FAKE_ACCESS_TOKEN = "EcLjvxdALOT0eq18d8Gzz3DEr3AMG27NtL+++YPSZNE=";
+
+const nockFundingRequest = (nodeAddress: string) =>
+  nock(FUNDING_SERVICE_URL).post(`/api/request/funds/${nodeAddress}`);
+const nockGetApiAccessToken =
+  nock(FUNDING_SERVICE_URL).get("/api/access-token");
+
+const mockNode = (
+  peerId?: string,
+  hasExitNode?: boolean
+): CreateRegisteredNode => ({
+  hasExitNode: hasExitNode ?? true,
+  peerId: peerId ?? "peerId",
+  chainId: 100,
+  hoprdApiEndpoint: "localhost",
+  hoprdApiPort: 5000,
+  exitNodePubKey: "somePubKey",
+  nativeAddress: "someAddress",
+});
+
+describe("test v1 router", function () {
+  let dbInstance: DBInstance;
+  let app: Express;
+
+  beforeAll(async function () {
+    dbInstance = MockPgInstanceSingleton.getDbInstance();
+    MockPgInstanceSingleton.getInitialState();
+  });
+
+  beforeEach(async function () {
+    MockPgInstanceSingleton.getInitialState().restore();
+    const fundingServiceApi = new FundingServiceApi(
+      FUNDING_SERVICE_URL,
+      dbInstance
+    );
+    app = express().use(
+      "",
+      v1Router({
+        db: dbInstance,
+        baseQuota: BASE_QUOTA,
+        accessToken: ACCESS_TOKEN,
+        fundingServiceApi,
+      })
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should register a node", async function () {
+    const node = mockNode();
+    await request(app).post("/node/register").send(node);
+    const createdNode = await request(app).get(`/node/${node.peerId}`);
+    assert.equal(createdNode.body.node.id, node.peerId);
+  });
+
+  it("should get a node", async function () {
+    const node = mockNode();
+    await request(app).post("/node/register").send(node);
+    await request(app).post("/node/register").send(mockNode("fake"));
+    const createdNode = await request(app).get(`/node/${node.peerId}`);
+    assert.equal(createdNode.body.node.id, node.peerId);
+  });
+
+  it("should get all nodes", async function () {
+    await request(app).post("/node/register").send(mockNode("notExit1", false));
+    await request(app).post("/node/register").send(mockNode("notExit2", false));
+    await request(app).post("/node/register").send(mockNode("exit3", true));
+    await request(app).post("/node/register").send(mockNode("exit4", true));
+
+    const allExitNodes = await request(app).get(`/node?hasExitNode=${false}`);
+
+    assert(typeof allExitNodes.body === "object" && allExitNodes.body.length);
+  });
+
+  it("should add quota to a client", async function () {
+    const createdQuota = await request(app).post("/client/funds").send({
+      client: "client",
+      quota: 1,
+    });
+    assert.equal(createdQuota.body.quota.quota, 1);
+  });
+
+  it.skip("should not allow request client does not have enough quota", async function () {
+    // create quota for client
+    await request(app).post("/client/funds").send({
+      client: "client",
+      quota: 1,
+    });
+    const doesClientHaveQuotaResponse = await doesClientHaveQuota(
+      dbInstance,
+      "client",
+      2
+    );
+
+    assert(!doesClientHaveQuotaResponse);
+  });
+  it("should allow request because client has enough quota", async function () {
+    // create quota for wrong client
+    await request(app).post("/client/funds").send({
+      client: "client",
+      quota: 1,
+    });
+    const doesClientHaveQuotaResponse = await doesClientHaveQuota(
+      dbInstance,
+      "client",
+      1
+    );
+
+    assert(doesClientHaveQuotaResponse);
+  });
+  describe("should select an entry node", function () {
+    it("should return an entry node", async function () {
+      const spy = jest.spyOn(registeredNode, "getEligibleNode");
+      const amountLeft = 10;
+      const peerId = "entry";
+      const requestId = 1;
+
+      nockGetApiAccessToken.reply(200, {
+        accessToken: FAKE_ACCESS_TOKEN,
+        amountLeft: 10,
+        expiredAt: new Date().toISOString(),
+      } as getAccessTokenResponse);
+
+      await request(app).post("/client/funds").send({
+        client: "client",
+        quota: 1,
+      });
+
+      await request(app).post("/node/register").send(mockNode(peerId, true));
+
+      const createdNode = (await request(app).get(`/node/${peerId}`)) as {
+        body: { node: QueryRegisteredNode | undefined };
+      };
+
+      spy.mockImplementation(async () => {
+        return createdNode.body.node;
+      });
+
+      nockFundingRequest(createdNode.body.node?.native_address!).reply(200, {
+        amountLeft,
+        id: requestId,
+      } as postFundingResponse);
+
+      const requestResponse = await request(app)
+        .post("/request/entry-node")
+        .send({ client: "client" });
+
+      if (!requestResponse.body || !createdNode.body.node)
+        throw new Error("Could not create mock nodes");
+
+      assert.equal(requestResponse.body.id, createdNode.body.node?.id);
+      spy.mockRestore();
+    });
+    it("should fail if no entry node is selected", async function () {
+      const spy = jest.spyOn(registeredNode, "getEligibleNode");
+
+      nockGetApiAccessToken.reply(200, {
+        accessToken: FAKE_ACCESS_TOKEN,
+        amountLeft: 10,
+        expiredAt: new Date().toISOString(),
+      } as getAccessTokenResponse);
+
+      await request(app).post("/client/funds").send({
+        client: "client",
+        quota: 1,
+      });
+
+      spy.mockImplementation(async () => undefined);
+
+      const requestResponse = await request(app)
+        .post("/request/entry-node")
+        .send({ client: "client" });
+
+      assert.equal(requestResponse.body.body, "Could not find eligible node");
+      spy.mockRestore();
+    });
+    it.skip("should reduce client quota", async function () {
+      const spy = jest.spyOn(registeredNode, "getEligibleNode");
+      const amountLeft = 10;
+      const peerId = "entry";
+      const requestId = 1;
+
+      nockGetApiAccessToken.reply(200, {
+        accessToken: FAKE_ACCESS_TOKEN,
+        amountLeft: 10,
+        expiredAt: new Date().toISOString(),
+      } as getAccessTokenResponse);
+
+      await request(app).post("/client/funds").send({
+        client: "newClient",
+        quota: BASE_QUOTA,
+      });
+
+      await request(app).post("/node/register").send(mockNode(peerId, true));
+
+      const createdNode = (await request(app).get(`/node/${peerId}`)) as {
+        body: { node: QueryRegisteredNode | undefined };
+      };
+
+      spy.mockImplementation(async () => {
+        return createdNode.body.node;
+      });
+
+      nockFundingRequest(createdNode.body.node?.native_address!).reply(200, {
+        amountLeft,
+        id: requestId,
+      } as postFundingResponse);
+
+      await request(app)
+        .post("/request/entry-node")
+        .send({ client: "newClient" });
+
+      const requestResponse = await request(app)
+        .post("/request/entry-node")
+        .send({ client: "newClient" });
+
+      assert.equal(
+        requestResponse.body.body,
+        "Client does not have enough quota"
+      );
+      spy.mockRestore();
+    });
+  });
+});

--- a/apps/discovery-platform/src/entry-server/routers/v1/index.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/index.ts
@@ -40,15 +40,19 @@ export const v1Router = (ops: {
   router.use(express.json());
 
   router.post("/node/register", async (req, res) => {
-    log.verbose("/node/register", req.body);
-    const node = req.body as CreateRegisteredNode;
+    log.verbose("POST /node/register", req.body);
+    const node: CreateRegisteredNode = req.body;
     const registered = await createRegisteredNode(ops.db, node);
     return res.json({ body: registered });
   });
 
   router.get("/node", async (req, res) => {
+    log.verbose("GET /node", req.body);
+
     const { hasExitNode } = req.query;
     if (hasExitNode === "true") {
+      log.verbose("GET /node", req.body);
+
       const nodes = await getExitNodes(ops.db);
       return res.json(nodes);
     } else {
@@ -58,27 +62,33 @@ export const v1Router = (ops: {
   });
 
   router.get("/node/:peerId", async (req, res) => {
-    const { peerId } = req.params;
-    const node = await getRegisteredNode(ops.db, peerId as string);
+    const { peerId }: { peerId: string } = req.params;
+    log.verbose(`GET /node/${peerId}`);
+    const node = await getRegisteredNode(ops.db, peerId);
     return res.json({ node });
   });
 
   router.get("/funding-service/funds", async (req, res) => {
+    log.verbose(`GET /funding-service/funds`);
+
     const funds = await ops.fundingServiceApi.getAvailableFunds();
     return res.json({ body: funds });
   });
 
   router.post("/client/funds", async (req, res) => {
-    const { client, quota } = req.body as CreateQuota;
+    log.verbose(`POST /client/funds`, req.body);
+
+    const { client, quota }: CreateQuota = req.body;
     const createdQuota = await createQuota(ops.db, {
       client,
       quota,
-      actionTaker: "discovery platform",
+      actionTaker: "discovery-platform",
     });
     return res.json({ quota: createdQuota });
   });
 
   router.post("/request/entry-node", async (req, res) => {
+    log.verbose(`POST /request/entry-node`, req.body);
     const { client } = req.body;
     log.verbose("requesting entry node for client", client);
     if (typeof client !== "string") throw Error("Client is not a string");

--- a/devkit/sandbox/src/add-quota.ts
+++ b/devkit/sandbox/src/add-quota.ts
@@ -20,7 +20,7 @@ const headers = {
 };
 
 const addQuota = async (): Promise<string> => {
-  const url = new URL("/api/client/funds", DP_API_ENDPOINT);
+  const url = new URL("/api/v1/client/funds", DP_API_ENDPOINT);
   const body = {
     client: CLIENT,
     quota: QUOTA,

--- a/devkit/sandbox/src/register-nodes.ts
+++ b/devkit/sandbox/src/register-nodes.ts
@@ -75,7 +75,7 @@ const registerNode = async (
   exitNodePubKey: string,
   nativeAddress: string
 ): Promise<string> => {
-  const url = new URL("/api/node/register", DP_API_ENDPOINT);
+  const url = new URL("/api/v1/node/register", DP_API_ENDPOINT);
   const body = {
     hasExitNode: true,
     peerId,

--- a/packages/ethers/src/index.spec.ts
+++ b/packages/ethers/src/index.spec.ts
@@ -71,7 +71,7 @@ describe("test index.ts", function () {
     .reply(202, "someresponse");
 
   nock(DISCOVERY_PLATFORM_API_ENDPOINT)
-    .post("/api/request/entry-node")
+    .post("/api/v1/request/entry-node")
     .reply(200, {
       hoprd_api_endpoint: ENTRY_NODE_API_ENDPOINT,
       hoprd_api_port: ENTRY_NODE_API_PORT,
@@ -81,7 +81,7 @@ describe("test index.ts", function () {
     .persist();
 
   nock(DISCOVERY_PLATFORM_API_ENDPOINT)
-    .get("/api/node?hasExitNode=true")
+    .get("/api/v1/node?hasExitNode=true")
     .reply(200, [
       {
         exit_node_pub_key: EXIT_NODE_PUB_KEY,

--- a/packages/sdk/src/index.spec.ts
+++ b/packages/sdk/src/index.spec.ts
@@ -42,7 +42,7 @@ const createSdkMock = (
     .reply(202, "someresponse");
 
   nock(DISCOVERY_PLATFORM_API_ENDPOINT)
-    .post("/api/request/entry-node")
+    .post("/api/v1/request/entry-node")
     .reply(200, {
       hoprd_api_endpoint: ENTRY_NODE_API_ENDPOINT,
       hoprd_api_port: ENTRY_NODE_API_PORT,
@@ -52,7 +52,7 @@ const createSdkMock = (
     .persist(true);
 
   nock(DISCOVERY_PLATFORM_API_ENDPOINT)
-    .get("/api/node?hasExitNode=true")
+    .get("/api/v1/node?hasExitNode=true")
     .reply(200, [
       {
         exit_node_pub_key: EXIT_NODE_PUB_KEY,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -101,7 +101,7 @@ export default class SDK {
       id: string;
     } = await fetch(
       new URL(
-        "/api/request/entry-node",
+        "/api/v1/request/entry-node",
         discoveryPlatformApiEndpoint
       ).toString(),
       {
@@ -142,7 +142,7 @@ export default class SDK {
       id: string;
     }[] = await fetch(
       new URL(
-        "/api/node?hasExitNode=true",
+        "/api/v1/node?hasExitNode=true",
         discoveryPlatformApiEndpoint
       ).toString()
     ).then((res) => res.json());


### PR DESCRIPTION
Closes #119 

### Overview
Added a router carpet in entry server where all versions can be separated, initially there is only one version which is v1

#### TODO
- [x] Add versioning to DP, endpoints should change from `/api/request/entry-node` -> `/api/v1/request/entry-node`
- [x] Update routes that depend on DP (calling entry node/registering nodes in sandbox/etc)
- [x] Update tests