### PR TITLE
add sanitization and validation to discovery platform

### DIFF
--- a/apps/discovery-platform/package.json
+++ b/apps/discovery-platform/package.json
@@ -12,24 +12,25 @@
     "start": "node build/index.js"
   },
   "devDependencies": {
-    "@types/express": "^4.17.14",
-    "@types/node-fetch": "2.6.2",
-    "@types/supertest": "^2.0.12",
-    "nock": "^13.2.9",
-    "pg-mem": "^2.6.4",
     "@rpch/configs-eslint": "*",
     "@rpch/configs-jest": "*",
     "@rpch/configs-prettier": "*",
     "@rpch/configs-tsup": "*",
     "@rpch/configs-typescript": "*",
+    "@types/express": "^4.17.14",
+    "@types/node-fetch": "2.6.2",
+    "@types/supertest": "^2.0.12",
+    "nock": "^13.2.9",
+    "pg-mem": "^2.6.4",
     "supertest": "^6.3.3"
   },
   "dependencies": {
+    "@rpch/common": "0.1.5",
     "express": "^4.18.2",
+    "express-validator": "^6.14.3",
     "graphql": "^16.6.0",
     "graphql-request": "^5.0.0",
     "node-fetch": "^2.6.2",
-    "pg-promise": "^11.0.0",
-    "@rpch/common": "0.1.5"
+    "pg-promise": "^11.0.0"
   }
 }

--- a/apps/discovery-platform/src/entry-server/routers/v1/index.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/index.ts
@@ -248,11 +248,6 @@ export const v1Router = (ops: {
           return res.status(400).json({ errors: errors.array() });
         }
         const { client, excludeList } = req.body;
-        if (typeof client !== "string") {
-          return res
-            .status(400)
-            .json({ body: "Expected client to be in the body" });
-        }
 
         // check if client has enough quota
         const doesClientHaveQuotaResponse = await doesClientHaveQuota(

--- a/apps/discovery-platform/src/entry-server/routers/v1/index.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/index.ts
@@ -143,7 +143,7 @@ export const v1Router = (ops: {
         const registered = await createRegisteredNode(ops.db, node);
         return res.json({ body: registered });
       } catch (e) {
-        log.error("Can not register node", JSON.stringify(e));
+        log.error("Can not register node", e);
         return res.status(500).json({ body: "Unexpected error" });
       }
     }
@@ -169,7 +169,7 @@ export const v1Router = (ops: {
         });
         return res.json(nodes);
       } catch (e) {
-        log.error("Can not get nodes", JSON.stringify(e));
+        log.error("Can not get nodes", e);
         return res.status(500).json({ body: "Unexpected error" });
       }
     }
@@ -189,7 +189,7 @@ export const v1Router = (ops: {
         const node = await getRegisteredNode(ops.db, peerId);
         return res.json({ node });
       } catch (e) {
-        log.error("Can not get node with id", JSON.stringify(e));
+        log.error("Can not get node with id", e);
         return res.status(500).json({ body: "Unexpected error" });
       }
     }
@@ -201,10 +201,7 @@ export const v1Router = (ops: {
       const funds = await ops.fundingServiceApi.getAvailableFunds();
       return res.json({ body: funds });
     } catch (e) {
-      log.error(
-        "Can not retrieve funds from funding service",
-        JSON.stringify(e)
-      );
+      log.error("Can not retrieve funds from funding service", e);
       return res.status(500).json({ body: "Unexpected error" });
     }
   });
@@ -228,7 +225,7 @@ export const v1Router = (ops: {
         });
         return res.json({ quota: createdQuota });
       } catch (e) {
-        log.error("Can not create funds", JSON.stringify(e));
+        log.error("Can not create funds", e);
         return res.status(500).json({ body: "Unexpected error" });
       }
     }
@@ -284,7 +281,7 @@ export const v1Router = (ops: {
         });
         return res.json({ ...selectedNode, accessToken: ops.accessToken });
       } catch (e) {
-        log.error("Can not retrieve entry node", JSON.stringify(e));
+        log.error("Can not retrieve entry node", e);
         return res.status(500).json({ body: "Unexpected error" });
       }
     }

--- a/apps/discovery-platform/src/entry-server/routers/v1/index.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/index.ts
@@ -1,4 +1,12 @@
-import express, { Request } from "express";
+import express, { Request, Response } from "express";
+import {
+  ParamSchema,
+  Schema,
+  body,
+  checkSchema,
+  param,
+  validationResult,
+} from "express-validator";
 import { DBInstance } from "../../../db";
 import { FundingServiceApi } from "../../../funding-service-api";
 import { createQuota, getAllQuotasByClient, sumQuotas } from "../../../quota";
@@ -6,8 +14,8 @@ import { CreateQuota } from "../../../quota/dto";
 import {
   createRegisteredNode,
   getEligibleNode,
-  getRegisteredNodes,
   getRegisteredNode,
+  getRegisteredNodes,
   getRewardForNode,
 } from "../../../registered-node";
 import { CreateRegisteredNode } from "../../../registered-node/dto";
@@ -18,16 +26,99 @@ const log = createLogger(["entry-server", "router", "v1"]);
 // base amount of reward that a node will receive after completing a request
 const BASE_EXTRA = 1;
 
-export const doesClientHaveQuota = async (
-  db: DBInstance,
-  client: string,
-  baseQuota: number
-) => {
-  const allQuotasFromClient = await getAllQuotasByClient(db, client);
-  const sumOfClientsQuota = sumQuotas(allQuotasFromClient);
-  return sumOfClientsQuota >= baseQuota;
+// Sanitization and Validation
+const registerNodeSchema: Record<keyof CreateRegisteredNode, ParamSchema> = {
+  peerId: {
+    in: "body",
+    exists: {
+      errorMessage: "Expected peerId to be in the body",
+      bail: true,
+    },
+    isString: true,
+  },
+  chainId: {
+    in: "body",
+    exists: {
+      errorMessage: "Expected chainId to be in the body",
+      bail: true,
+    },
+    isNumeric: true,
+    toInt: true,
+  },
+  exitNodePubKey: {
+    in: "body",
+    exists: {
+      errorMessage: "Expected exitNodePubKey to be in the body",
+      bail: true,
+    },
+    isString: true,
+  },
+  hasExitNode: {
+    in: "body",
+    exists: {
+      errorMessage: "Expected hasExitNode to be in the body",
+      bail: true,
+    },
+    isBoolean: true,
+    toBoolean: true,
+  },
+  hoprdApiEndpoint: {
+    in: "body",
+    exists: {
+      errorMessage: "Expected hoprdApiEndpoint to be in the body",
+      bail: true,
+    },
+    isString: true,
+  },
+  hoprdApiPort: {
+    in: "body",
+    exists: {
+      errorMessage: "Expected hoprdApiPort to be in the body",
+      bail: true,
+    },
+    isNumeric: true,
+    toInt: true,
+  },
+  nativeAddress: {
+    in: "body",
+    exists: {
+      errorMessage: "Expected nativeAddress to be in the body",
+      bail: true,
+    },
+    isString: true,
+  },
 };
 
+const getNodeSchema: Record<
+  keyof { excludeList?: string; hasExitNode?: string },
+  ParamSchema
+> = {
+  excludeList: {
+    optional: true,
+    in: "query",
+    custom: {
+      options: (value) => {
+        return isExcludeListSafe(value);
+      },
+    },
+  },
+  hasExitNode: {
+    optional: true,
+    in: "query",
+    isBoolean: true,
+  },
+};
+
+const isExcludeListSafe = (value: string) => {
+  // check that the exclude list only has ids and commas
+  const noSpecialCharsRegex = /^[a-zA-Z0-9]+$/;
+  if (noSpecialCharsRegex.test(value)) return true;
+
+  const alphanumericCommaRegex = /^[a-zA-Z0-9,]+$/;
+  return alphanumericCommaRegex.test(value);
+};
+
+// Express Router
 export const v1Router = (ops: {
   db: DBInstance;
   baseQuota: number;
@@ -38,102 +129,181 @@ export const v1Router = (ops: {
 
   router.use(express.json());
 
-  router.post("/node/register", async (req, res) => {
-    log.verbose("POST /node/register", req.body);
-    const node: CreateRegisteredNode = req.body;
-    const registered = await createRegisteredNode(ops.db, node);
-    return res.json({ body: registered });
-  });
-
-  router.get(
-    "/node",
-    async (
-      req: Request<{}, {}, {}, { excludeList?: string; hasExitNode?: string }>,
-      res
-    ) => {
-      log.verbose("GET /node", req.query);
-
-      const { hasExitNode, excludeList } = req.query;
-      const nodes = await getRegisteredNodes(ops.db, {
-        excludeList: excludeList?.split(", "),
-        hasExitNode: hasExitNode === "true",
-      });
-      return res.json(nodes);
+  router.post(
+    "/node/register",
+    checkSchema(registerNodeSchema),
+    async (req: Request, res: Response) => {
+      try {
+        log.verbose("POST /node/register", req.body);
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+          return res.status(400).json({ errors: errors.array() });
+        }
+        const node: CreateRegisteredNode = req.body;
+        const registered = await createRegisteredNode(ops.db, node);
+        return res.json({ body: registered });
+      } catch (e) {
+        log.error("Can not register node", JSON.stringify(e));
+        return res.status(500).json({ body: "Unexpected error" });
+      }
     }
   );
 
-  router.get("/node/:peerId", async (req, res) => {
-    const { peerId }: { peerId: string } = req.params;
-    log.verbose(`GET /node/${peerId}`);
-    const node = await getRegisteredNode(ops.db, peerId);
-    return res.json({ node });
-  });
+  router.get(
+    "/node",
+    checkSchema(getNodeSchema),
+    async (
+      req: Request<{}, {}, {}, { excludeList?: string; hasExitNode?: string }>,
+      res: Response
+    ) => {
+      try {
+        log.verbose("GET /node", req.query);
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+          return res.status(400).json({ errors: errors.array() });
+        }
+        const { hasExitNode, excludeList } = req.query;
+        const nodes = await getRegisteredNodes(ops.db, {
+          excludeList: excludeList?.split(", "),
+          hasExitNode: hasExitNode ? hasExitNode === "true" : undefined,
+        });
+        return res.json(nodes);
+      } catch (e) {
+        log.error("Can not get nodes", JSON.stringify(e));
+        return res.status(500).json({ body: "Unexpected error" });
+      }
+    }
+  );
+
+  router.get(
+    "/node/:peerId",
+    param("peerId").isAlphanumeric(),
+    async (req: Request<{ peerId: string }>, res: Response) => {
+      try {
+        log.verbose(`GET /node/:peerId`, req.params);
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+          return res.status(400).json({ errors: errors.array() });
+        }
+        const { peerId }: { peerId: string } = req.params;
+        const node = await getRegisteredNode(ops.db, peerId);
+        return res.json({ node });
+      } catch (e) {
+        log.error("Can not get node with id", JSON.stringify(e));
+        return res.status(500).json({ body: "Unexpected error" });
+      }
+    }
+  );
 
   router.get("/funding-service/funds", async (req, res) => {
     log.verbose(`GET /funding-service/funds`);
-
-    const funds = await ops.fundingServiceApi.getAvailableFunds();
-    return res.json({ body: funds });
+    try {
+      const funds = await ops.fundingServiceApi.getAvailableFunds();
+      return res.json({ body: funds });
+    } catch (e) {
+      log.error(
+        "Can not retrieve funds from funding service",
+        JSON.stringify(e)
+      );
+      return res.status(500).json({ body: "Unexpected error" });
+    }
   });
 
-  router.post("/client/funds", async (req, res) => {
-    log.verbose(`POST /client/funds`, req.body);
-
-    const { client, quota }: CreateQuota = req.body;
-    const createdQuota = await createQuota(ops.db, {
-      client,
-      quota,
-      actionTaker: "discovery-platform",
-    });
-    return res.json({ quota: createdQuota });
-  });
-
-  router.post("/request/entry-node", async (req, res) => {
-    log.verbose(`POST /request/entry-node`, req.body);
-    const { client, excludeList } = req.body;
-
-    log.verbose("requesting entry node for client", client);
-    if (typeof client !== "string") {
-      return res
-        .status(400)
-        .json({ body: "Expected client to be in the body" });
+  router.post(
+    "/client/funds",
+    body("client").exists().bail().isAlphanumeric(),
+    body("quota").exists().bail().isNumeric(),
+    async (req, res) => {
+      try {
+        log.verbose(`POST /client/funds`, req.body);
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+          return res.status(400).json({ errors: errors.array() });
+        }
+        const { client, quota }: CreateQuota = req.body;
+        const createdQuota = await createQuota(ops.db, {
+          client,
+          quota,
+          actionTaker: "discovery-platform",
+        });
+        return res.json({ quota: createdQuota });
+      } catch (e) {
+        log.error("Can not create funds", JSON.stringify(e));
+        return res.status(500).json({ body: "Unexpected error" });
+      }
     }
+  );
 
-    // check if client has enough quota
-    const doesClientHaveQuotaResponse = await doesClientHaveQuota(
-      ops.db,
-      client,
-      ops.baseQuota
-    );
-    if (!doesClientHaveQuotaResponse) {
-      return res.status(403).json({
-        body: "Client does not have enough quota",
-      });
+  router.post(
+    "/request/entry-node",
+    body("client").exists().bail().isAlphanumeric(),
+    body("excludeList")
+      .optional()
+      .custom((value) => isExcludeListSafe(value)),
+    async (req, res) => {
+      try {
+        log.verbose(`POST /request/entry-node`, req.body);
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+          return res.status(400).json({ errors: errors.array() });
+        }
+        const { client, excludeList } = req.body;
+        if (typeof client !== "string") {
+          return res
+            .status(400)
+            .json({ body: "Expected client to be in the body" });
+        }
+
+        // check if client has enough quota
+        const doesClientHaveQuotaResponse = await doesClientHaveQuota(
+          ops.db,
+          client,
+          ops.baseQuota
+        );
+        if (!doesClientHaveQuotaResponse) {
+          return res.status(403).json({
+            body: "Client does not have enough quota",
+          });
+        }
+        // choose selected entry node
+        const selectedNode = await getEligibleNode(ops.db, { excludeList });
+        log.verbose("selected entry node", selectedNode);
+        if (!selectedNode) {
+          return res.status(404).json({ body: "Could not find eligible node" });
+        }
+
+        // calculate how much should be funded to entry node
+        const amountToFund = getRewardForNode(
+          ops.baseQuota,
+          BASE_EXTRA,
+          selectedNode
+        );
+        // fund entry node
+        await ops.fundingServiceApi.requestFunds(amountToFund, selectedNode);
+
+        // create negative quota (showing that the client has used up initial quota)
+        await createQuota(ops.db, {
+          client,
+          quota: ops.baseQuota * -1,
+          actionTaker: "discovery platform",
+        });
+        return res.json({ ...selectedNode, accessToken: ops.accessToken });
+      } catch (e) {
+        log.error("Can not retrieve entry node", JSON.stringify(e));
+        return res.status(500).json({ body: "Unexpected error" });
+      }
     }
-    // choose selected entry node
-    const selectedNode = await getEligibleNode(ops.db, { excludeList });
-    log.verbose("selected entry node", selectedNode);
-    if (!selectedNode) {
-      return res.status(404).json({ body: "Could not find eligible node" });
-    }
-
-    // calculate how much should be funded to entry node
-    const amountToFund = getRewardForNode(
-      ops.baseQuota,
-      BASE_EXTRA,
-      selectedNode
-    );
-    // fund entry node
-    await ops.fundingServiceApi.requestFunds(amountToFund, selectedNode);
-
-    // create negative quota (showing that the client has used up initial quota)
-    await createQuota(ops.db, {
-      client,
-      quota: ops.baseQuota * -1,
-      actionTaker: "discovery platform",
-    });
-    return res.json({ ...selectedNode, accessToken: ops.accessToken });
-  });
+  );
 
   return router;
+};
+
+export const doesClientHaveQuota = async (
+  db: DBInstance,
+  client: string,
+  baseQuota: number
+) => {
+  const allQuotasFromClient = await getAllQuotasByClient(db, client);
+  const sumOfClientsQuota = sumQuotas(allQuotasFromClient);
+  return sumOfClientsQuota >= baseQuota;
 };

--- a/apps/discovery-platform/src/index.ts
+++ b/apps/discovery-platform/src/index.ts
@@ -76,7 +76,7 @@ const start = async (ops: {
       log.normal("tracking pending requests");
       await fundingServiceApi.checkForPendingRequests();
     } catch (e) {
-      log.error("Failed to track pending requests", JSON.stringify(e));
+      log.error("Failed to track pending requests", e);
     }
   }, 1000);
 
@@ -104,10 +104,7 @@ const start = async (ops: {
         }
       }
     } catch (e) {
-      log.error(
-        "Failed to check commitment for fresh nodes",
-        JSON.stringify(e)
-      );
+      log.error("Failed to check commitment for fresh nodes", e);
     }
   }, 1000);
 

--- a/apps/discovery-platform/src/index.ts
+++ b/apps/discovery-platform/src/index.ts
@@ -72,31 +72,42 @@ const start = async (ops: {
 
   // keep track of all pending funding requests to update status or retry
   const checkForPendingRequests = setInterval(async () => {
-    log.normal("tracking pending requests");
-    await fundingServiceApi.checkForPendingRequests();
+    try {
+      log.normal("tracking pending requests");
+      await fundingServiceApi.checkForPendingRequests();
+    } catch (e) {
+      log.error("Failed to track pending requests", JSON.stringify(e));
+    }
   }, 1000);
 
   // check if fresh nodes have committed
   const checkCommitmentForFreshNodes = setInterval(async () => {
-    log.normal("tracking commitment for fresh nodes");
-    const freshNodes = await getRegisteredNodes(ops.db, {
-      status: "FRESH",
-    });
-
-    for (const node of freshNodes ?? []) {
-      log.verbose("checking commitment of fresh node", node);
-
-      const nodeIsCommitted = await checkCommitment({
-        node,
-        minBalance: constants.BALANCE_THRESHOLD,
-        minChannels: constants.CHANNELS_THRESHOLD,
+    try {
+      log.normal("tracking commitment for fresh nodes");
+      const freshNodes = await getRegisteredNodes(ops.db, {
+        status: "FRESH",
       });
 
-      log.verbose("node commitment", nodeIsCommitted);
-      if (nodeIsCommitted) {
-        log.verbose("new committed node", node.id);
-        await updateRegisteredNode(ops.db, { ...node, status: "READY" });
+      for (const node of freshNodes ?? []) {
+        log.verbose("checking commitment of fresh node", node);
+
+        const nodeIsCommitted = await checkCommitment({
+          node,
+          minBalance: constants.BALANCE_THRESHOLD,
+          minChannels: constants.CHANNELS_THRESHOLD,
+        });
+
+        log.verbose("node commitment", nodeIsCommitted);
+        if (nodeIsCommitted) {
+          log.verbose("new committed node", node.id);
+          await updateRegisteredNode(ops.db, { ...node, status: "READY" });
+        }
       }
+    } catch (e) {
+      log.error(
+        "Failed to check commitment for fresh nodes",
+        JSON.stringify(e)
+      );
     }
   }, 1000);
 

--- a/apps/discovery-platform/src/registered-node/index.ts
+++ b/apps/discovery-platform/src/registered-node/index.ts
@@ -73,10 +73,12 @@ export const getEligibleNode = async (
     ...filters,
     status: "READY",
   });
-  // choose selected entry node
-  const selectedNode = utils.randomlySelectFromArray(readyNodes);
-  // TODO: get access token of selected node
-  return selectedNode;
+  if (readyNodes.length) {
+    // choose selected entry node
+    const selectedNode = utils.randomlySelectFromArray(readyNodes);
+    // TODO: get access token of selected node
+    return selectedNode;
+  }
 };
 
 /**

--- a/apps/funding-service/src/entry-server/index.ts
+++ b/apps/funding-service/src/entry-server/index.ts
@@ -29,17 +29,22 @@ export const entryServer = (ops: {
   app.use(express.json());
 
   app.get("/api/access-token", async (req, res) => {
-    log.verbose("GET /api/access-token");
-    const accessToken = await ops.accessTokenService.createAccessToken({
-      amount: ops.maxAmountOfTokens,
-      timeout: ops.timeout,
-    });
-    return res.json({
-      accessToken: accessToken?.token,
-      expiredAt: accessToken?.expired_at,
-      createdAt: accessToken?.created_at,
-      amountLeft: ops.maxAmountOfTokens,
-    });
+    try {
+      log.verbose("GET /api/access-token");
+      const accessToken = await ops.accessTokenService.createAccessToken({
+        amount: ops.maxAmountOfTokens,
+        timeout: ops.timeout,
+      });
+      return res.json({
+        accessToken: accessToken?.token,
+        expiredAt: accessToken?.expired_at,
+        createdAt: accessToken?.created_at,
+        amountLeft: ops.maxAmountOfTokens,
+      });
+    } catch (e) {
+      log.error("Can not create access token", JSON.stringify(e));
+      return res.status(500).json({ body: "Unexpected error" });
+    }
   });
 
   app.post(
@@ -53,42 +58,47 @@ export const entryServer = (ops: {
       true
     ),
     async (req, res) => {
-      log.verbose(
-        `POST /api/request/funds/:blockchainAddress`,
-        req.params,
-        req.body
-      );
-
-      // check if validation failed
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({ errors: errors.array() });
-      }
-      const nodeAddress = String(req.params.blockchainAddress);
-      const amount = String(req.body.amount);
-      const chainId = Number(req.body.chainId);
-
-      // can be enforced because the existence is checked in the middleware
-      const accessTokenHash: string | undefined =
-        req.headers["x-access-token"]!.toString();
-
-      const request = await ops.requestService.createRequest({
-        nodeAddress,
-        amount,
-        accessTokenHash,
-        chainId,
-      });
-      const allUnresolvedAndSuccessfulRequestsByAccessToken =
-        await ops.requestService.getAllUnresolvedAndSuccessfulRequestsByAccessToken(
-          accessTokenHash
+      try {
+        log.verbose(
+          `POST /api/request/funds/:blockchainAddress`,
+          req.params,
+          req.body
         );
-      const amountUsed = ops.requestService.sumAmountOfRequests(
-        allUnresolvedAndSuccessfulRequestsByAccessToken
-      );
-      return res.json({
-        id: request.id,
-        amountLeft: ops.maxAmountOfTokens - amountUsed[chainId],
-      });
+
+        // check if validation failed
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+          return res.status(400).json({ errors: errors.array() });
+        }
+        const nodeAddress = String(req.params.blockchainAddress);
+        const amount = String(req.body.amount);
+        const chainId = Number(req.body.chainId);
+
+        // can be enforced because the existence is checked in the middleware
+        const accessTokenHash: string | undefined =
+          req.headers["x-access-token"]!.toString();
+
+        const request = await ops.requestService.createRequest({
+          nodeAddress,
+          amount,
+          accessTokenHash,
+          chainId,
+        });
+        const allUnresolvedAndSuccessfulRequestsByAccessToken =
+          await ops.requestService.getAllUnresolvedAndSuccessfulRequestsByAccessToken(
+            accessTokenHash
+          );
+        const amountUsed = ops.requestService.sumAmountOfRequests(
+          allUnresolvedAndSuccessfulRequestsByAccessToken
+        );
+        return res.json({
+          id: request.id,
+          amountLeft: ops.maxAmountOfTokens - amountUsed[chainId],
+        });
+      } catch (e) {
+        log.error("Can not request funding", JSON.stringify(e));
+        return res.status(500).json({ body: "Unexpected error" });
+      }
     }
   );
 
@@ -100,9 +110,14 @@ export const entryServer = (ops: {
       ops.maxAmountOfTokens
     ),
     async (req, res) => {
-      log.verbose(`GET /api/request/status`);
-      const requests = await ops.requestService.getRequests();
-      return res.status(200).json(requests);
+      try {
+        log.verbose(`GET /api/request/status`);
+        const requests = await ops.requestService.getRequests();
+        return res.status(200).json(requests);
+      } catch (e) {
+        log.error("Can not get status for requests", JSON.stringify(e));
+        return res.status(500).json({ body: "Unexpected error" });
+      }
     }
   );
 
@@ -115,15 +130,20 @@ export const entryServer = (ops: {
       ops.maxAmountOfTokens
     ),
     async (req, res) => {
-      log.verbose(`GET /api/request/status/:requestId`, req.params);
-      // check if validation failed
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({ errors: errors.array() });
+      try {
+        log.verbose(`GET /api/request/status/:requestId`, req.params);
+        // check if validation failed
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+          return res.status(400).json({ errors: errors.array() });
+        }
+        const requestId = Number(req.params.requestId);
+        const request = await ops.requestService.getRequest(requestId);
+        return res.status(200).json(request);
+      } catch (e) {
+        log.error("Can not get status for a single request", JSON.stringify(e));
+        return res.status(500).json({ body: "Unexpected error" });
       }
-      const requestId = Number(req.params.requestId);
-      const request = await ops.requestService.getRequest(requestId);
-      return res.status(200).json(request);
     }
   );
 
@@ -135,35 +155,40 @@ export const entryServer = (ops: {
       ops.maxAmountOfTokens
     ),
     async (req, res) => {
-      log.verbose(`GET /api/funds`);
-      log.verbose([
-        "getting funds for chains",
-        [...Object.keys(constants.CONNECTION_INFO)],
-      ]);
-      const providers = await getProviders(
-        [...Object.keys(constants.CONNECTION_INFO)].map(Number)
-      );
-      const balances = await getBalanceForAllChains(
-        constants.SMART_CONTRACTS_PER_CHAIN,
-        ops.walletAddress,
-        providers
-      );
-      const compromisedRequests =
-        await ops.requestService.getAllUnresolvedRequests();
-      const frozenBalances = await ops.requestService.sumAmountOfRequests(
-        compromisedRequests ?? []
-      );
+      try {
+        log.verbose(`GET /api/funds`);
+        log.verbose([
+          "getting funds for chains",
+          [...Object.keys(constants.CONNECTION_INFO)],
+        ]);
+        const providers = await getProviders(
+          [...Object.keys(constants.CONNECTION_INFO)].map(Number)
+        );
+        const balances = await getBalanceForAllChains(
+          constants.SMART_CONTRACTS_PER_CHAIN,
+          ops.walletAddress,
+          providers
+        );
+        const compromisedRequests =
+          await ops.requestService.getAllUnresolvedRequests();
+        const frozenBalances = await ops.requestService.sumAmountOfRequests(
+          compromisedRequests ?? []
+        );
 
-      const availableBalances = ops.requestService.calculateAvailableFunds(
-        balances,
-        frozenBalances
-      );
+        const availableBalances = ops.requestService.calculateAvailableFunds(
+          balances,
+          frozenBalances
+        );
 
-      // all balances are in wei
-      return res.json({
-        available: availableBalances,
-        frozen: frozenBalances,
-      });
+        // all balances are in wei
+        return res.json({
+          available: availableBalances,
+          frozen: frozenBalances,
+        });
+      } catch (e) {
+        log.error("Can not get status for a single request", JSON.stringify(e));
+        return res.status(500).json({ body: "Unexpected error" });
+      }
     }
   );
 

--- a/apps/funding-service/src/entry-server/index.ts
+++ b/apps/funding-service/src/entry-server/index.ts
@@ -42,7 +42,7 @@ export const entryServer = (ops: {
         amountLeft: ops.maxAmountOfTokens,
       });
     } catch (e) {
-      log.error("Can not create access token", JSON.stringify(e));
+      log.error("Can not create access token", e);
       return res.status(500).json({ body: "Unexpected error" });
     }
   });
@@ -96,7 +96,7 @@ export const entryServer = (ops: {
           amountLeft: ops.maxAmountOfTokens - amountUsed[chainId],
         });
       } catch (e) {
-        log.error("Can not request funding", JSON.stringify(e));
+        log.error("Can not request funding", e);
         return res.status(500).json({ body: "Unexpected error" });
       }
     }
@@ -115,7 +115,7 @@ export const entryServer = (ops: {
         const requests = await ops.requestService.getRequests();
         return res.status(200).json(requests);
       } catch (e) {
-        log.error("Can not get status for requests", JSON.stringify(e));
+        log.error("Can not get status for requests", e);
         return res.status(500).json({ body: "Unexpected error" });
       }
     }
@@ -141,7 +141,7 @@ export const entryServer = (ops: {
         const request = await ops.requestService.getRequest(requestId);
         return res.status(200).json(request);
       } catch (e) {
-        log.error("Can not get status for a single request", JSON.stringify(e));
+        log.error("Can not get status for a single request", e);
         return res.status(500).json({ body: "Unexpected error" });
       }
     }
@@ -186,7 +186,7 @@ export const entryServer = (ops: {
           frozen: frozenBalances,
         });
       } catch (e) {
-        log.error("Can not get status for a single request", JSON.stringify(e));
+        log.error("Can not get status for a single request", e);
         return res.status(500).json({ body: "Unexpected error" });
       }
     }

--- a/apps/funding-service/src/queue/index.ts
+++ b/apps/funding-service/src/queue/index.ts
@@ -147,7 +147,11 @@ export const checkFreshRequests = async (ops: {
         });
       }
     } else {
-      log.error("Could not fulfill request", e);
+      if (e instanceof CustomError) {
+        log.error("Could not fulfill pending request", e.message);
+      } else {
+        log.error("Unexpected error trying to fulfill pending request", e);
+      }
     }
   } finally {
     ops.changeState(false);

--- a/apps/funding-service/src/queue/index.ts
+++ b/apps/funding-service/src/queue/index.ts
@@ -114,7 +114,6 @@ export const checkFreshRequests = async (ops: {
       id: freshRequest.id,
     });
   } catch (e: any) {
-    log.error("Could not fulfill request", e);
     if (freshRequest) {
       // check if request was rejected
       if (e instanceof CustomError) {
@@ -147,6 +146,8 @@ export const checkFreshRequests = async (ops: {
           id: freshRequest.id,
         });
       }
+    } else {
+      log.error("Could not fulfill request", e);
     }
   } finally {
     ops.changeState(false);

--- a/apps/funding-service/src/queue/index.ts
+++ b/apps/funding-service/src/queue/index.ts
@@ -114,7 +114,7 @@ export const checkFreshRequests = async (ops: {
       id: freshRequest.id,
     });
   } catch (e: any) {
-    log.error(e);
+    log.error("Could not fulfill request", e);
     if (freshRequest) {
       // check if request was rejected
       if (e instanceof CustomError) {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -341,6 +341,9 @@ export default class SDK {
   private isDeadlocked(): boolean {
     if (!this.deadlockTimestamp) return false;
     const now = Date.now();
+    if (now < this.deadlockTimestamp) {
+      log.verbose("SDK is deadlocked until", this.deadlockTimestamp);
+    }
     return now < this.deadlockTimestamp;
   }
 

--- a/packages/sdk/src/reliability-score.ts
+++ b/packages/sdk/src/reliability-score.ts
@@ -152,13 +152,13 @@ export default class ReliabilityScore {
       } else if (sent < this.FRESH_NODE_THRESHOLD) {
         this.score.set(peerId, FRESH_NODE_SCORE);
         log.normal(
-          "node %s is a fresh node with 0.2 realiability score",
+          "node %s is a fresh node with 0.2 reliability score",
           peerId
         );
       } else {
         const score = (sent - failed) / sent;
         this.score.set(peerId, score);
-        log.normal("node %s has a %s realiability score", peerId, score);
+        log.normal("node %s has a %s reliability score", peerId, score);
       }
       return this.score.get(peerId)!;
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4266,6 +4266,14 @@ express-validator@^6.14.2:
     lodash "^4.17.21"
     validator "^13.7.0"
 
+express-validator@^6.14.3:
+  version "6.14.3"
+  resolved "https://registry.yarnpkg.com/express-validator/-/express-validator-6.14.3.tgz#50787258c1250ffb0e7a697f05e9f16aa2fd8084"
+  integrity sha512-c4b9NMdhskfcLbH/FchsSfCt4Vb14gKzcotG9zLS+VoOJDox57aGhCL+kmAu7cl+ytaSed+HD5jdJhel8DQsdg==
+  dependencies:
+    lodash "^4.17.21"
+    validator "^13.7.0"
+
 express@^4.18.2:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"


### PR DESCRIPTION
Fixes #155 

### Todo
- [x] Add `express-validator` to Discovery platform and validate and sanitize all endpoints
- [x] Update status codes in Discovery platform, this includes adding a `try catch` block to handle unexpected errors
- [x] Update status codes in Funding service, this includes adding a `try catch` block to handle unexpected errors
