### PR TITLE
Fix Discovery Platform nodes stuck on funding

### DIFF
--- a/apps/discovery-platform/src/db/index.spec.ts
+++ b/apps/discovery-platform/src/db/index.spec.ts
@@ -134,7 +134,6 @@ describe("test db functions", function () {
     const notExcludedNodes = await db.getRegisteredNodes(dbInstance, {
       excludeList: ["2"],
     });
-    console.log(notExcludedNodes);
     assert.equal(notExcludedNodes.length, 2);
     assert.equal(
       notExcludedNodes.findIndex((node) => node.id === "2"),

--- a/apps/discovery-platform/src/entry-server/routers/v1/index.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/index.ts
@@ -271,7 +271,10 @@ export const v1Router = (ops: {
           selectedNode
         );
         // fund entry node
-        await ops.fundingServiceApi.requestFunds(amountToFund, selectedNode);
+        await ops.fundingServiceApi.requestFunds({
+          amount: amountToFund,
+          node: selectedNode,
+        });
 
         // create negative quota (showing that the client has used up initial quota)
         await createQuota(ops.db, {

--- a/apps/discovery-platform/src/funding-service-api/index.ts
+++ b/apps/discovery-platform/src/funding-service-api/index.ts
@@ -26,10 +26,12 @@ export class FundingServiceApi {
   private amountLeft: number | undefined;
   // Map of all pending requests
   private pendingRequests: Map<
-    //peerId
-    string,
-    { amountOfRetries: number; requestId: number }
+    //requestId
+    number,
+    { amountOfRetries: number; previousRequestId: number; peerId: string }
   > = new Map();
+  // Amount of times a request can fail and be sent again
+  private maxAmountOfRetries = 3;
 
   constructor(private url: string, private db: DBInstance) {}
 
@@ -103,13 +105,15 @@ export class FundingServiceApi {
    * @param prevRetries number of times funding request has failed
    * @returns
    */
-  public async requestFunds(
-    amount: number,
-    node: QueryRegisteredNode,
-    prevRetries?: number
-  ) {
+  public async requestFunds(params: {
+    amount: number;
+    node: QueryRegisteredNode;
+    previousRequestId?: number;
+    amountOfRetries?: number;
+  }) {
     try {
       await this.getAccessToken();
+      const { amount, node } = params;
       const dbNode = await getRegisteredNode(this.db, node.id);
       if (!dbNode) throw new Error("Node is not registered");
       log.verbose("requesting to funding service", {
@@ -157,7 +161,12 @@ export class FundingServiceApi {
       });
 
       this.amountLeft = amountLeft;
-      this.savePendingRequest(node.id, requestId, prevRetries ?? 0);
+      this.savePendingRequest({
+        requestId,
+        peerId: node.id,
+        previousRequestId: params.previousRequestId,
+        amountOfRetries: params.amountOfRetries,
+      });
       return requestId;
     } catch (e: any) {
       throw new Error(e.message);
@@ -202,14 +211,16 @@ export class FundingServiceApi {
   /**
    * Save new request to pending requests so we can track it
    */
-  private savePendingRequest(
-    peerId: string,
-    requestId: number,
-    amountOfRetries: number
-  ) {
-    this.pendingRequests.set(peerId, {
-      amountOfRetries: amountOfRetries,
-      requestId: requestId,
+  private savePendingRequest(params: {
+    requestId: number;
+    peerId: string;
+    previousRequestId?: number;
+    amountOfRetries?: number;
+  }) {
+    this.pendingRequests.set(params.requestId, {
+      previousRequestId: params.previousRequestId ?? 0,
+      amountOfRetries: params.amountOfRetries ?? 0,
+      peerId: params.peerId,
     });
   }
 
@@ -219,14 +230,13 @@ export class FundingServiceApi {
   public async checkForPendingRequests() {
     log.verbose(
       "pending requests",
-      this.pendingRequests.size
-        ? [...this.pendingRequests.values()].map((req) => req.requestId)
-        : []
+      this.pendingRequests.size ? [...this.pendingRequests.keys()] : []
     );
+    const snapshotPendingRequests = [...this.pendingRequests.entries()];
     for (const [
-      peerId,
-      { amountOfRetries, requestId },
-    ] of this.pendingRequests.entries()) {
+      requestId,
+      { amountOfRetries, previousRequestId, peerId },
+    ] of snapshotPendingRequests) {
       log.verbose("handling pending request", requestId);
       const request = await this.getRequestStatus(String(requestId));
       const node = await getRegisteredNode(this.db, peerId);
@@ -234,35 +244,61 @@ export class FundingServiceApi {
       if (!node) throw new Error("Registered node does not exist");
 
       log.verbose(
-        "pending funding request status and node",
-        request.status,
-        node
+        `request id: ${requestId} is in status ${request.status}
+        for node ${node.id}`
       );
+
       // checks if it should prune
       if (
         request.status === "SUCCESS" ||
         request.status === "REJECTED-DURING-PROCESSING"
       ) {
         await updateRegisteredNode(this.db, {
-          ...node!,
+          ...node,
           status: request.status === "SUCCESS" ? "READY" : "UNUSABLE",
           total_amount_funded:
             node.total_amount_funded + Number(request.amount),
         });
-        log.verbose("Request has been fulfilled", requestId, peerId);
-        this.pendingRequests.delete(peerId);
+        log.verbose(
+          "request has been fulfilled",
+          request.status,
+          requestId,
+          peerId
+        );
+        this.pendingRequests.delete(requestId);
 
         // check if it should retry
       } else if (
         request.status === "FAILED" ||
         request.status === "FAILED-DURING-PROCESSING"
       ) {
-        log.verbose("retrying request for node", node);
-        const requestId = await this.requestFunds(
-          Number(request.amount),
-          node!
-        );
-        this.savePendingRequest(node.id, requestId, amountOfRetries + 1);
+        if (amountOfRetries < this.maxAmountOfRetries) {
+          log.verbose("retrying request for node", node);
+          const previousRequestId = requestId;
+          const newRequestId = await this.requestFunds({
+            amount: Number(request.amount),
+            node: node,
+            amountOfRetries: amountOfRetries + 1,
+            previousRequestId,
+          });
+          log.verbose(
+            `deleting old request id ${previousRequestId} because 
+            request will be fulfilled with request id ${newRequestId}`
+          );
+          this.pendingRequests.delete(previousRequestId);
+          this.savePendingRequest({
+            peerId: node.id,
+            requestId: newRequestId,
+            amountOfRetries: amountOfRetries + 1,
+            previousRequestId,
+          });
+        } else {
+          log.error(
+            `could not fund node ${node.id} with request id ${requestId} 
+            and previous request id ${previousRequestId}`
+          );
+          this.pendingRequests.delete(requestId);
+        }
       }
     }
   }

--- a/apps/discovery-platform/src/graph-api/index.ts
+++ b/apps/discovery-platform/src/graph-api/index.ts
@@ -55,10 +55,7 @@ export const checkCommitment = async (ops: {
 }): Promise<boolean | undefined> => {
   try {
     // eslint-disable-next-line turbo/no-undeclared-env-vars
-    log.verbose(
-      "check commitment environment",
-      constants.SKIP_CHECK_COMMITMENT
-    );
+    log.verbose("skip check commitment", constants.SKIP_CHECK_COMMITMENT);
     // Assume node has committed to hopr if it is running in development
     // eslint-disable-next-line turbo/no-undeclared-env-vars
     if (constants.SKIP_CHECK_COMMITMENT) return true;


### PR DESCRIPTION
Fixes #163 
Fixes #164 

### Overview
The problem that was tackled here is that when requesting funds from funding service and the token was invalid we did not `await` the response from funding service and used the old invalid access token which caused a lot of inconstancies that have been handled in this pr. Another thing that is changed in this pr is that we can handle various funding requests per node instead of limiting one pending funding requests per node.

- fix token validation
- don't save funding_requests when request id is undefined
- change in pending requests map structure to: 
```
 // Map of all pending requests
  private pendingRequests: Map<
    //requestId
    number,
    { amountOfRetries: number; previousRequestId: number; peerId: string }
  > = new Map();
```