### PR TITLE
sdk handle failed messages to hoprd

### DIFF
--- a/packages/common/src/hoprd.spec.ts
+++ b/packages/common/src/hoprd.spec.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import nock from "nock";
 import * as hoprd from "./hoprd";
 import * as fixtures from "./fixtures";
+import debug from "debug";
 
 const ENTRY_NODE_API_ENDPOINT = "http://entry_node";
 const ENTRY_NODE_API_TOKEN = "12345";
@@ -22,18 +23,25 @@ describe("test hoprd.ts / sendMessage", function () {
     assert.equal(res, "someresponse");
   });
 
-  it("log error when response is not status 202", async function () {
+  it.only("log and throw error when response is not status 202", async function () {
     fixtures.nockSendMessageApi(nock(ENTRY_NODE_API_ENDPOINT)).reply(422, {
       status: "UNKNOWN_FAILURE",
       error: "Full error message.",
     });
-
-    const res = await hoprd.sendMessage({
-      apiEndpoint: ENTRY_NODE_API_ENDPOINT,
-      apiToken: ENTRY_NODE_API_TOKEN,
-      destination: EXIT_NODE_PEER_ID,
-      message: "hello",
-    });
-    assert.equal(res, undefined);
+    const logSpy = jest.spyOn(console, "log");
+    try {
+      await hoprd.sendMessage({
+        apiEndpoint: ENTRY_NODE_API_ENDPOINT,
+        apiToken: ENTRY_NODE_API_TOKEN,
+        destination: EXIT_NODE_PEER_ID,
+        message: "hello",
+      });
+    } catch (e: any) {
+      expect(logSpy).toHaveBeenCalled();
+      assert.equal(
+        e.message,
+        '{"status":"UNKNOWN_FAILURE","error":"Full error message."}'
+      );
+    }
   });
 });

--- a/packages/common/src/hoprd.spec.ts
+++ b/packages/common/src/hoprd.spec.ts
@@ -23,12 +23,11 @@ describe("test hoprd.ts / sendMessage", function () {
     assert.equal(res, "someresponse");
   });
 
-  it.only("log and throw error when response is not status 202", async function () {
+  it("throw error when response is not status 202", async function () {
     fixtures.nockSendMessageApi(nock(ENTRY_NODE_API_ENDPOINT)).reply(422, {
       status: "UNKNOWN_FAILURE",
       error: "Full error message.",
     });
-    const logSpy = jest.spyOn(console, "log");
     try {
       await hoprd.sendMessage({
         apiEndpoint: ENTRY_NODE_API_ENDPOINT,
@@ -37,7 +36,6 @@ describe("test hoprd.ts / sendMessage", function () {
         message: "hello",
       });
     } catch (e: any) {
-      expect(logSpy).toHaveBeenCalled();
       assert.equal(
         e.message,
         '{"status":"UNKNOWN_FAILURE","error":"Full error message."}'

--- a/packages/common/src/hoprd.ts
+++ b/packages/common/src/hoprd.ts
@@ -42,12 +42,13 @@ export const sendMessage = async ({
     const text = await response.text();
     return text;
   } else {
+    let errorMessage = await response.text();
     log.error(
       "failed to send message to HOPRd node",
       response.status,
-      await response.text()
+      errorMessage
     );
-    throw new Error(await response.text());
+    throw new Error(errorMessage);
   }
 };
 

--- a/packages/common/src/hoprd.ts
+++ b/packages/common/src/hoprd.ts
@@ -47,6 +47,7 @@ export const sendMessage = async ({
       response.status,
       await response.text()
     );
+    throw new Error(await response.text());
   }
 };
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -371,12 +371,17 @@ export default class SDK {
       const segments = message.toSegments();
       this.requestCache.addRequest(req, resolve, reject);
       for (const segment of segments) {
-        hoprd.sendMessage({
-          apiEndpoint: this.entryNode!.apiEndpoint,
-          apiToken: this.entryNode!.apiToken,
-          message: segment.toString(),
-          destination: this.exitNode!.peerId,
-        });
+        hoprd
+          .sendMessage({
+            apiEndpoint: this.entryNode!.apiEndpoint,
+            apiToken: this.entryNode!.apiToken,
+            message: segment.toString(),
+            destination: this.exitNode!.peerId,
+          })
+          .catch((e) => {
+            log.error("failed to send message to hoprd", segment.toString(), e);
+            reject("failed to send message to hoprd");
+          });
       }
     });
   }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -380,6 +380,8 @@ export default class SDK {
           })
           .catch((e) => {
             log.error("failed to send message to hoprd", segment.toString(), e);
+            this.onRequestRemoval(req);
+            this.requestCache.removeRequest(req);
             reject("failed to send message to hoprd");
           });
       }


### PR DESCRIPTION
Fixes #158 

### How it works
If hoprd doesn't respond a status code `202`, we will reject the request straight away because we know that at least 1 message will not go through