### PR TITLE
Add test to make sure network version can be obtained

### DIFF
--- a/devkit/e2e/src/e2e.spec.ts
+++ b/devkit/e2e/src/e2e.spec.ts
@@ -43,4 +43,9 @@ describe("e2e tests", function () {
     );
     assert.equal(balance._isBigNumber, true);
   });
+
+  it("should get network version", async function () {
+    const network = await provider.send("net_version", []);
+    assert.equal(network, 100);
+  });
 });


### PR DESCRIPTION
Fixes #175 

Looks like riga removes this bug, added e2e of the method to show that it can work.