### PR TITLE
Update registered nodes to status READY after failing funding requests

### DIFF
--- a/apps/discovery-platform/src/funding-service-api/index.ts
+++ b/apps/discovery-platform/src/funding-service-api/index.ts
@@ -295,6 +295,10 @@ export class FundingServiceApi {
             and previous request id ${previousRequestId}`
           );
           this.pendingRequests.delete(requestId);
+          await updateRegisteredNode(this.db, {
+            ...node,
+            status: "READY",
+          });
         }
       }
     }


### PR DESCRIPTION
Fixes #199 

For Alpha, if funding has not gone through successfully nodes will go back to status `READY`.