### PR TITLE
Handle error codes when requesting funds to funding service

### DIFF
--- a/apps/discovery-platform/package.json
+++ b/apps/discovery-platform/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@rpch/common": "0.1.5",
+    "async-retry": "^1.3.3",
     "express": "^4.18.2",
     "express-validator": "^6.14.3",
     "graphql": "^16.6.0",

--- a/apps/discovery-platform/package.json
+++ b/apps/discovery-platform/package.json
@@ -17,6 +17,7 @@
     "@rpch/configs-prettier": "*",
     "@rpch/configs-tsup": "*",
     "@rpch/configs-typescript": "*",
+    "@types/async-retry": "^1.4.5",
     "@types/express": "^4.17.14",
     "@types/node-fetch": "2.6.2",
     "@types/supertest": "^2.0.12",

--- a/apps/discovery-platform/src/funding-service-api/index.spec.ts
+++ b/apps/discovery-platform/src/funding-service-api/index.spec.ts
@@ -230,6 +230,7 @@ describe("test funding service api class", function () {
         expiredAt: new Date(Date.now()).toISOString(),
       };
 
+      // all access tokens expire straight away so it calls for access token 2 per run
       nockGetApiAccessToken.times(6).reply(200, getAccessTokenResponse);
 
       const postFundingResponseBody: postFundingResponse = {
@@ -291,9 +292,7 @@ describe("test funding service api class", function () {
       const amountLeft = 10;
       const requestId = 123;
 
-      nockGetApiAccessToken
-        .times(10)
-        .reply(200, successfulGetApiAccessTokenBody);
+      nockGetApiAccessToken.twice().reply(200, successfulGetApiAccessTokenBody);
 
       const successfulPostFundingBody: postFundingResponse = {
         amountLeft,

--- a/apps/discovery-platform/src/funding-service-api/index.spec.ts
+++ b/apps/discovery-platform/src/funding-service-api/index.spec.ts
@@ -263,11 +263,6 @@ describe("test funding service api class", function () {
       // get 3 access tokens
       nockGetApiAccessToken.times(3).reply(200, getAccessTokenResponse);
 
-      const postFundingResponseBody: postFundingResponse = {
-        amountLeft,
-        id: requestId,
-      };
-
       // fail first time
       nockFundingRequest(node.native_address).reply(500, "Error");
 

--- a/apps/discovery-platform/src/funding-service-api/index.ts
+++ b/apps/discovery-platform/src/funding-service-api/index.ts
@@ -296,8 +296,7 @@ export class FundingServiceApi {
     opts?: retry.Options | undefined
   ): Promise<Response> {
     const res = await retry(
-      async (bail, attempt) => {
-        log.verbose({ attempt });
+      async (bail) => {
         await this.getAccessToken(amount);
         const body: postFundingRequest = {
           amount: String(amount),
@@ -319,6 +318,7 @@ export class FundingServiceApi {
         log.verbose(res, res.status, res.status === 500);
 
         if (401 === res.status) {
+          await this.fetchAccessToken();
           throw new Error("access token is no longer valid");
         }
 

--- a/apps/discovery-platform/src/funding-service-api/index.ts
+++ b/apps/discovery-platform/src/funding-service-api/index.ts
@@ -1,4 +1,4 @@
-import fetch from "node-fetch";
+import fetch, { Response } from "node-fetch";
 import {
   getAccessTokenResponse,
   getRequestStatusResponse,
@@ -11,6 +11,7 @@ import { DBInstance } from "../db";
 import { getRegisteredNode, updateRegisteredNode } from "../registered-node";
 import { createLogger } from "../utils";
 import { createFundingRequest } from "../funding-requests";
+import retry from "async-retry";
 
 const log = createLogger(["funding-service-api"]);
 
@@ -112,41 +113,24 @@ export class FundingServiceApi {
     amountOfRetries?: number;
   }) {
     try {
-      await this.getAccessToken();
       const { amount, node } = params;
       const dbNode = await getRegisteredNode(this.db, node.id);
       if (!dbNode) throw new Error("Node is not registered");
+
       log.verbose("requesting to funding service", {
-        amount: String(amount),
-        chainId: node.chain_id,
-        peerId: node.id,
+        amount: amount.toString(),
+        chainId: dbNode.chain_id,
+        peerId: dbNode.id,
       });
 
-      const body: postFundingRequest = {
-        amount: String(amount),
-        chainId: node.chain_id,
-      };
-      const res = await fetch(
-        `${this.url}/api/request/funds/${dbNode.native_address}`,
-        {
-          method: "POST",
-          headers: {
-            "x-access-token": this.accessToken!,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(body),
-        }
-      );
+      const res = await this.fetchRequestFunds(dbNode, amount);
 
       let fundingResponseJson = await res.json();
+
       log.verbose("funding service response", fundingResponseJson);
+
       const { id: requestId, amountLeft }: postFundingResponse =
         fundingResponseJson;
-
-      if (!requestId) {
-        log.error("funding request failed", fundingResponseJson);
-        throw new Error("funding request failed: " + fundingResponseJson);
-      }
 
       await updateRegisteredNode(this.db, { ...dbNode, status: "FUNDING" });
 
@@ -158,12 +142,14 @@ export class FundingServiceApi {
       });
 
       this.amountLeft = amountLeft;
+
       this.savePendingRequest({
         requestId,
         peerId: node.id,
         previousRequestId: params.previousRequestId,
         amountOfRetries: params.amountOfRetries,
       });
+
       return requestId;
     } catch (e: any) {
       throw new Error(e.message);
@@ -302,5 +288,59 @@ export class FundingServiceApi {
         }
       }
     }
+  }
+
+  public async fetchRequestFunds(
+    dbNode: QueryRegisteredNode,
+    amount: number,
+    opts?: retry.Options | undefined
+  ): Promise<Response> {
+    const res = await retry(
+      async (bail, attempt) => {
+        log.verbose({ attempt });
+        await this.getAccessToken(amount);
+        const body: postFundingRequest = {
+          amount: String(amount),
+          chainId: dbNode.chain_id,
+        };
+        // if anything throws, we retry
+        const res = await fetch(
+          `${this.url}/api/request/funds/${dbNode.native_address}`,
+          {
+            method: "POST",
+            headers: {
+              "x-access-token": this.accessToken!,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(body),
+          }
+        );
+
+        log.verbose(res, res.status, res.status === 500);
+
+        if (401 === res.status) {
+          throw new Error("access token is no longer valid");
+        }
+
+        if (500 === res.status || 400 == res.status || 404 === res.status) {
+          // don't retry upon 500, 400 or 404
+          log.error("funding request failed", await res.text());
+          bail(new Error("funding request failed"));
+          return;
+        }
+
+        return res;
+      },
+      {
+        retries: 3,
+        ...opts,
+      }
+    );
+
+    if (!res) {
+      throw new Error("funding request failed");
+    }
+
+    return res;
   }
 }


### PR DESCRIPTION
Fix #217 

### Overview
- installed `async-retry`
- added tests to check retries
- separated asking for funds to funding service from db side effects (setting node to FUNDING, etc) 