### PR TITLE
use bullseye-slim

### DIFF
--- a/apps/discovery-platform/Dockerfile
+++ b/apps/discovery-platform/Dockerfile
@@ -1,7 +1,7 @@
 # Create discovery platform
 
 # use slim version of node on Debian bullseye for smaller image sizes
-FROM node:16-bullseye-slim@sha256:2e42e0aab9c9fd2d914417659ebedb4f995dfde79f3f7127cbc7e57ae6485dd9 as builder
+FROM node:16-bullseye-slim as builder
 
 # use bash to have source command and persistent environment.
 SHELL ["/bin/bash", "-lc"]
@@ -18,7 +18,7 @@ COPY . .
 RUN turbo prune --scope="@rpch/discovery-platform" --docker
 
 # Add lockfile and package.json's of isolated subworkspace.
-FROM node:16-alpine AS installer
+FROM node:16-bullseye-slim AS installer
 RUN apk add --no-cache libc6-compat
 RUN apk update
 WORKDIR /app
@@ -35,7 +35,7 @@ COPY turbo.json turbo.json
 RUN yarn run build --scope="@rpch/discovery-platform"
 
 #  Copy only the necesary files to run the app.
-FROM node:16-alpine AS runner
+FROM node:16-bullseye-slim AS runner
 WORKDIR /app
 
 # we use tini as process 1 to catch signals properly, which is also built into Docker by default

--- a/apps/exit-node/Dockerfile
+++ b/apps/exit-node/Dockerfile
@@ -2,7 +2,7 @@
 
 # use slim version of node on Debian bullseye for smaller image sizes
 # Specify platform to be amd because arm doesn't work
-FROM --platform=linux/amd64 node:16-bullseye-slim@sha256:2e42e0aab9c9fd2d914417659ebedb4f995dfde79f3f7127cbc7e57ae6485dd9 as builder
+FROM --platform=linux/amd64 node:16-bullseye-slim as builder
 
 # use bash to have source command and persistent environment.
 SHELL ["/bin/bash", "-lc"]
@@ -32,7 +32,7 @@ RUN turbo prune --scope="@rpch/exit-node" --docker
 
 # Add lockfile and package.json's of isolated subworkspace.
 # Specify platform to be amd because arm doesn't work
-FROM --platform=linux/amd64 node:16-alpine AS installer
+FROM --platform=linux/amd64 node:16-bullseye-slim AS installer
 RUN apk add --no-cache libc6-compat
 RUN apk update
 WORKDIR /app
@@ -50,7 +50,7 @@ RUN yarn run build --scope="@rpch/exit-node"
 
 #  Copy only the necesary files to run the app.
 # Specify platform to be amd because arm doesn't work
-FROM --platform=linux/amd64 node:16-alpine AS runner
+FROM --platform=linux/amd64 node:16-bullseye-slim AS runner
 
 WORKDIR /app
 

--- a/apps/funding-service/Dockerfile
+++ b/apps/funding-service/Dockerfile
@@ -1,7 +1,7 @@
 # Create funding service
 
 # use slim version of node on Debian bullseye for smaller image sizes
-FROM node:16-bullseye-slim@sha256:2e42e0aab9c9fd2d914417659ebedb4f995dfde79f3f7127cbc7e57ae6485dd9 as builder
+FROM node:16-bullseye-slim as builder
 
 # use bash to have source command and persistent environment.
 SHELL ["/bin/bash", "-lc"]
@@ -18,7 +18,7 @@ COPY . .
 RUN turbo prune --scope="@rpch/funding-service" --docker
 
 # Add lockfile and package.json's of isolated subworkspace.
-FROM node:16-alpine AS installer
+FROM node:16-bullseye-slim AS installer
 RUN apk add --no-cache libc6-compat
 RUN apk update
 WORKDIR /app
@@ -35,7 +35,7 @@ COPY turbo.json turbo.json
 RUN yarn run build --scope="@rpch/funding-service"
 
 #  Copy only the necesary files to run the app.
-FROM node:16-alpine AS runner
+FROM node:16-bullseye-slim AS runner
 WORKDIR /app
 
 # we use tini as process 1 to catch signals properly, which is also built into Docker by default

--- a/apps/rpc-server/Dockerfile
+++ b/apps/rpc-server/Dockerfile
@@ -2,7 +2,7 @@
 
 # use slim version of node on Debian bullseye for smaller image sizes
 # Specify platform to be amd because arm doesn't work
-FROM --platform=linux/amd64 node:16-bullseye-slim@sha256:2e42e0aab9c9fd2d914417659ebedb4f995dfde79f3f7127cbc7e57ae6485dd9 as builder
+FROM --platform=linux/amd64 node:16-bullseye-slim as builder
 
 # use bash to have source command and persistent environment.
 SHELL ["/bin/bash", "-lc"]
@@ -32,7 +32,7 @@ RUN turbo prune --scope="@rpch/rpc-server" --docker
 
 # Add lockfile and package.json's of isolated subworkspace.
 # Specify platform to be amd because arm doesn't work
-FROM --platform=linux/amd64 node:16-alpine AS installer
+FROM --platform=linux/amd64 node:16-bullseye-slim AS installer
 RUN apk add --no-cache libc6-compat
 RUN apk update
 WORKDIR /app
@@ -50,7 +50,7 @@ RUN yarn run build --scope="@rpch/rpc-server"
 
 #  Copy only the necesary files to run the app.
 # Specify platform to be amd because arm doesn't work
-FROM --platform=linux/amd64 node:16-alpine AS runner
+FROM --platform=linux/amd64 node:16-bullseye-slim AS runner
 
 WORKDIR /app
 

--- a/devkit/manager/Dockerfile
+++ b/devkit/manager/Dockerfile
@@ -1,7 +1,7 @@
 # Create funding service
 
 # use slim version of node on Debian bullseye for smaller image sizes
-FROM node:16-bullseye-slim@sha256:2e42e0aab9c9fd2d914417659ebedb4f995dfde79f3f7127cbc7e57ae6485dd9 as builder
+FROM node:16-bullseye-slim as builder
 
 # use bash to have source command and persistent environment.
 SHELL ["/bin/bash", "-lc"]
@@ -18,7 +18,7 @@ COPY . .
 RUN turbo prune --scope="@rpch/manager" --docker
 
 # Add lockfile and package.json's of isolated subworkspace.
-FROM node:16-alpine AS installer
+FROM node:16-bullseye-slim AS installer
 RUN apk add --no-cache libc6-compat
 RUN apk update
 WORKDIR /app
@@ -35,7 +35,7 @@ COPY turbo.json turbo.json
 RUN yarn run build --scope="@rpch/manager"
 
 #  Copy only the necesary files to run the app.
-FROM node:16-alpine AS runner
+FROM node:16-bullseye-slim AS runner
 WORKDIR /app
 
 # we use tini as process 1 to catch signals properly, which is also built into Docker by default


### PR DESCRIPTION
`rpc-server` is running into this issue https://github.com/nodejs/docker-node/issues/1030#issuecomment-956122581
updating to `bullseye-slim` adds about `45MB` more to our images but helps avoid unnesessary trouble in the long term