### PR TITLE
sdk code hygiene

### DIFF
--- a/packages/sdk/src/index.spec.ts
+++ b/packages/sdk/src/index.spec.ts
@@ -180,6 +180,7 @@ describe("test SDK class", function () {
 
     afterEach(async function () {
       await sdk.stop();
+      nock.cleanAll();
       jest.clearAllMocks();
     });
 
@@ -354,6 +355,17 @@ describe("test SDK class", function () {
       assert.equal(sdk.fetchExitNodes.mock.calls.length, 1);
       // @ts-ignore
       assert.equal(sdk.exitNodes.length, 1);
+    });
+
+    it("should throw error when fetching exit nodes returns status code different to 200", async function () {
+      DP_GET_NODES.once().reply(500);
+      try {
+        await sdk["fetchExitNodes"](DISCOVERY_PLATFORM_API_ENDPOINT);
+      } catch (e) {
+        if (e instanceof Error) {
+          assert.equal(e.message, "Failed to fetch exit nodes");
+        }
+      }
     });
 
     it("should throw error when no entry node is available", async function () {

--- a/packages/sdk/src/index.spec.ts
+++ b/packages/sdk/src/index.spec.ts
@@ -202,6 +202,7 @@ describe("test SDK class", function () {
         fixtures.generateMockedFlow(3);
 
       sdk.sendRequest(clientRequest).then((response) => {
+        // this will run when .onMessage resolves request
         assert.equal(response.id, clientRequest.id);
         // @ts-ignore
         const pendingRequest = sdk.requestCache.getRequest(clientRequest.id);
@@ -209,6 +210,7 @@ describe("test SDK class", function () {
         done();
       });
 
+      // return response for sdk sendRequest
       // @ts-ignore
       sdk.onMessage(exitNodeResponse.toMessage());
     });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -20,7 +20,7 @@ const log = createLogger();
 // max number of segments sdk can send to entry node
 const MAXIMUM_SEGMENTS_PER_REQUEST = 100;
 const DEADLOCK_MS = 1e3 * 60 * 0.5; // 30s
-
+const MINIMUM_SCORE_FOR_RELIABLE_NODE = 0.7;
 /**
  * HOPR SDK options.
  */
@@ -385,7 +385,7 @@ export default class SDK {
     );
     const exclusionList: string[] = [];
     if (
-      entryNodeScore < 0.7 &&
+      entryNodeScore < MINIMUM_SCORE_FOR_RELIABLE_NODE &&
       this.reliabilityScore.getStatus(this.entryNode!.peerId) === "NON_FRESH"
     ) {
       log.verbose("node is not reliable enough. selecting new entry node");

--- a/packages/sdk/src/reliability-score.spec.ts
+++ b/packages/sdk/src/reliability-score.spec.ts
@@ -6,6 +6,27 @@ const ENTRY_NODE_PEER_ID = fixtures.HOPRD_PEER_ID_A;
 const FRESH_NODE_THRESHOLD = 20;
 const MAX_RESPONSES = 100;
 
+/**
+ * By using `ReliabilityScore.addMetric()`, adds n amount of metrics to a given node with a specified result.
+ * @param amount
+ * @param peerId
+ * @param result
+ */
+const addNumberOfMetrics = (
+  amount: number,
+  peerId: string,
+  result: Result,
+  reliabilityScore: ReliabilityScore
+) => {
+  for (let count = 1; count <= amount; count++) {
+    reliabilityScore.addMetric(
+      peerId,
+      utils.generatePseudoRandomId(1e6),
+      result
+    );
+  }
+};
+
 describe("test reliability score class", () => {
   let reliabilityScore: ReliabilityScore;
 
@@ -16,26 +37,73 @@ describe("test reliability score class", () => {
     );
   });
 
-  /**
-   * By using `ReliabilityScore.addMetric()`, adds n amount of metrics to a given node with a specified result.
-   * @param amount
-   * @param peerId
-   * @param result
-   */
-  const addNumberOfMetrics = (
-    amount: number,
-    peerId: string,
-    result: Result
-  ) => {
-    for (let count = 1; count <= amount; count++) {
-      reliabilityScore.addMetric(
-        peerId,
-        utils.generatePseudoRandomId(1e6),
-        result
-      );
-    }
-  };
   describe("metrics:", () => {
+    describe("get node metrics", function () {
+      it("returns default metrics if node is not registered", function () {
+        const peerId = "testPeerId";
+        const nodeMetrics = reliabilityScore["getNodeMetrics"](peerId);
+        expect(nodeMetrics.responses.size).toBe(0);
+        expect(nodeMetrics.stats.success).toBe(0);
+        expect(nodeMetrics.stats.dishonest).toBe(0);
+        expect(nodeMetrics.stats.failed).toBe(0);
+        expect(nodeMetrics.sent).toBe(0);
+        expect(nodeMetrics.updatedAt).toBeInstanceOf(Date);
+      });
+      it("returns metrics if node is registered", function () {
+        const peerId = "testPeerId";
+        const requestId = 1;
+        const result = "success";
+        reliabilityScore.addMetric(peerId, requestId, result);
+
+        const nodeMetrics = reliabilityScore["getNodeMetrics"](peerId);
+
+        expect(nodeMetrics.responses.size).toBe(1);
+        expect(nodeMetrics.stats.success).toBe(1);
+        expect(nodeMetrics.stats.dishonest).toBe(0);
+        expect(nodeMetrics.stats.failed).toBe(0);
+        expect(nodeMetrics.sent).toBe(1);
+        expect(nodeMetrics.updatedAt).toBeInstanceOf(Date);
+      });
+    });
+    it("updates node metrics", function () {
+      const peerId = "testPeerId";
+      const requestId = 1;
+      const result = "success";
+      let nodeMetrics = reliabilityScore["getNodeMetrics"](peerId);
+
+      reliabilityScore["updateNodeMetrics"](
+        peerId,
+        requestId,
+        result,
+        nodeMetrics
+      );
+
+      nodeMetrics = reliabilityScore["getNodeMetrics"](peerId);
+
+      expect(nodeMetrics.responses.size).toBe(1);
+      expect(nodeMetrics.stats.success).toBe(1);
+      expect(nodeMetrics.stats.dishonest).toBe(0);
+      expect(nodeMetrics.stats.failed).toBe(0);
+      expect(nodeMetrics.sent).toBe(1);
+    });
+    it("should reset metrics", function () {
+      const peerId = "testPeerId";
+      addNumberOfMetrics(
+        FRESH_NODE_THRESHOLD + 1,
+        peerId,
+        "success",
+        reliabilityScore
+      );
+      let nodeMetrics = reliabilityScore["getNodeMetrics"](peerId);
+
+      reliabilityScore["resetNodeMetrics"](peerId, nodeMetrics);
+
+      expect(nodeMetrics.responses.size).toBe(1);
+      expect(nodeMetrics.stats.success).toBe(1);
+      expect(nodeMetrics.stats.dishonest).toBe(0);
+      expect(nodeMetrics.stats.failed).toBe(0);
+      expect(nodeMetrics.sent).toBe(1);
+    });
     it("should add metrics", () => {
       reliabilityScore.addMetric(ENTRY_NODE_PEER_ID, 1, "success");
       reliabilityScore.addMetric(ENTRY_NODE_PEER_ID, 2, "dishonest");
@@ -47,7 +115,6 @@ describe("test reliability score class", () => {
       expect(entryNode?.sent).toBe(3);
       expect(entryNode?.responses.size).toBe(3);
     });
-
     it("shouldn't have stats for nonexistent nodes", () => {
       // @ts-ignore-next-line
       const stats = reliabilityScore.getResultsStats("nonexistentPeerId");
@@ -56,34 +123,33 @@ describe("test reliability score class", () => {
     });
 
     it("should remove all responses when MAX_RESPONSES is surpassed", () => {
-      addNumberOfMetrics(90, ENTRY_NODE_PEER_ID, "success");
-      addNumberOfMetrics(10, ENTRY_NODE_PEER_ID, "failed");
+      addNumberOfMetrics(90, ENTRY_NODE_PEER_ID, "success", reliabilityScore);
+      addNumberOfMetrics(10, ENTRY_NODE_PEER_ID, "failed", reliabilityScore);
 
       // @ts-ignore-next-line
       const entryNode = reliabilityScore.metrics.get(ENTRY_NODE_PEER_ID);
       expect(entryNode?.responses.size).toBe(100);
       expect(entryNode?.sent).toBe(100);
 
-      addNumberOfMetrics(5, ENTRY_NODE_PEER_ID, "success");
+      addNumberOfMetrics(5, ENTRY_NODE_PEER_ID, "success", reliabilityScore);
       expect(entryNode?.responses.size).toBe(5);
       expect(entryNode?.sent).toBe(5);
     });
     it("should remove all responses when MAX_RESPONSES is surpassed except dishonest ones", () => {
       // Adding 100 responses
-      addNumberOfMetrics(90, ENTRY_NODE_PEER_ID, "success");
-      addNumberOfMetrics(8, ENTRY_NODE_PEER_ID, "failed");
-      addNumberOfMetrics(2, ENTRY_NODE_PEER_ID, "dishonest");
+      addNumberOfMetrics(90, ENTRY_NODE_PEER_ID, "success", reliabilityScore);
+      addNumberOfMetrics(8, ENTRY_NODE_PEER_ID, "failed", reliabilityScore);
+      addNumberOfMetrics(2, ENTRY_NODE_PEER_ID, "dishonest", reliabilityScore);
 
       // @ts-ignore-next-line
       const entryNode = reliabilityScore.metrics.get(ENTRY_NODE_PEER_ID);
 
-      addNumberOfMetrics(1, ENTRY_NODE_PEER_ID, "success");
+      addNumberOfMetrics(1, ENTRY_NODE_PEER_ID, "success", reliabilityScore);
       expect(entryNode?.sent).toBe(1);
 
       // 2 dishonest responses and 1 successful.
       expect(entryNode?.responses.size).toBe(3);
     });
-    it.todo("should set metrics");
   });
   describe("scores:", () => {
     it("should have a score of 0.2 for nonexistent peerIds (fresh nodes)", () => {
@@ -92,8 +158,8 @@ describe("test reliability score class", () => {
       expect(score).toBe(0.2);
     });
     it("should have score of 0 for dishonest nodes", () => {
-      addNumberOfMetrics(19, ENTRY_NODE_PEER_ID, "success");
-      addNumberOfMetrics(1, ENTRY_NODE_PEER_ID, "dishonest");
+      addNumberOfMetrics(19, ENTRY_NODE_PEER_ID, "success", reliabilityScore);
+      addNumberOfMetrics(1, ENTRY_NODE_PEER_ID, "dishonest", reliabilityScore);
 
       const score = reliabilityScore.getScore(ENTRY_NODE_PEER_ID);
 
@@ -106,8 +172,8 @@ describe("test reliability score class", () => {
       expect(score).toBe(0.2);
     });
     it("should calculate score for ready nodes", () => {
-      addNumberOfMetrics(20, ENTRY_NODE_PEER_ID, "success");
-      addNumberOfMetrics(2, ENTRY_NODE_PEER_ID, "failed");
+      addNumberOfMetrics(20, ENTRY_NODE_PEER_ID, "success", reliabilityScore);
+      addNumberOfMetrics(2, ENTRY_NODE_PEER_ID, "failed", reliabilityScore);
 
       // score = (22 - 2)/22 => 0.9090909090909091
       expect(reliabilityScore.getScore(ENTRY_NODE_PEER_ID)).toBe(
@@ -139,9 +205,9 @@ describe("test reliability score class", () => {
       }
     });
 
-    it("should reset scores after treshold", () => {
-      addNumberOfMetrics(70, ENTRY_NODE_PEER_ID, "success");
-      addNumberOfMetrics(30, ENTRY_NODE_PEER_ID, "failed");
+    it("should reset scores after threshold", () => {
+      addNumberOfMetrics(70, ENTRY_NODE_PEER_ID, "success", reliabilityScore);
+      addNumberOfMetrics(30, ENTRY_NODE_PEER_ID, "failed", reliabilityScore);
       const beforeRecalculationScore =
         reliabilityScore.getScore(ENTRY_NODE_PEER_ID);
       reliabilityScore.addMetric(ENTRY_NODE_PEER_ID, 1, "success");


### PR DESCRIPTION
references [improve codebase hygiene n1#266](https://github.com/Rpc-h/RPCh/issues/266)

## Overview
Implements changes spoken about during architecture week

### Fixes
- added validation to exit node query -> checks if it is a 200 response
- added a more descriptive variable for 0.7 variable which is now MINIMUM_SCORE_FOR_RELIABLE_NODE
- added comments to tests where onmessage is seen
- removed isdeadlocked check from create request
- added tsdocs for reliability score constructor and removed redundancy
- simplify add metric -> split up into 3 functions that now update, reset and get metrics separating concerns.

