### PR TITLE
Fix exit-node Docker Compose

### DIFF
--- a/apps/exit-node/docker-compose.yml
+++ b/apps/exit-node/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - RPCH_DATA_DIR=${RPCH_DATA_DIR}
     entrypoint:
       [
-        "/bin/wait-for",
+        "/bin/wait-for-it.sh",
         "http://${HOPRD_API_TOKEN}@hoprd:3001/api/v2/account/addresses",
         "-t",
         "300",

--- a/devkit/sandbox/src/.env
+++ b/devkit/sandbox/src/.env
@@ -2,7 +2,7 @@
 DEBUG="hopr*,rpch*,-*metrics"
 
 # The HOPR_PLUTO_VERSION is a variable used by HOPR PLUTO to use an specific GCP image
-HOPR_PLUTO_VERSION=1.93.0
+HOPR_PLUTO_VERSION=1.92.12
 
 # central: SECRET key to use for funding-service and discovery-platform
 SECRET_KEY="PleaseChangeMe"


### PR DESCRIPTION
This pull request aims to fix a bug in the exit-node Docker Compose file where it tried using `/bin/wait-for` when it's not used anymore, but instead it was changed for `/bin/wait-for-it.sh`.