### PR TITLE
Disable funding service from sandbox

### DIFF
--- a/devkit/sandbox/src/central-docker-compose.yml
+++ b/devkit/sandbox/src/central-docker-compose.yml
@@ -25,6 +25,27 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
 
+  funding-service:
+    build:
+      dockerfile: apps/funding-service/Dockerfile
+      context: ../../../
+    depends_on:
+      - postgres-db
+    restart: unless-stopped
+    ports:
+      - "3010:3010"
+    networks:
+      - sandbox-proxy
+    environment:
+      - DEBUG=${DEBUG}
+      - PORT=3010
+      - SECRET_KEY=${SECRET_KEY}
+      - WALLET_PRIV_KEY=${FUNDING_SERVICE_PRIVATE_KEY}
+      - DB_CONNECTION_URL=postgresql://postgres:postgres@postgres-db:5432
+      - FORCE_CHAIN_ID=31337
+      - FORCE_RPC_URL=${RPC_PROVIDER}
+      - FORCE_SMART_CONTRACT_ADDRESS=${FORCE_SMART_CONTRACT_ADDRESS}
+
   discovery-platform:
     build:
       dockerfile: apps/discovery-platform/Dockerfile

--- a/devkit/sandbox/src/central-docker-compose.yml
+++ b/devkit/sandbox/src/central-docker-compose.yml
@@ -25,26 +25,26 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
 
-  funding-service:
-    build:
-      dockerfile: apps/funding-service/Dockerfile
-      context: ../../../
-    depends_on:
-      - postgres-db
-    restart: unless-stopped
-    ports:
-      - "3010:3010"
-    networks:
-      - sandbox-proxy
-    environment:
-      - DEBUG=${DEBUG}
-      - PORT=3010
-      - SECRET_KEY=${SECRET_KEY}
-      - WALLET_PRIV_KEY=${FUNDING_SERVICE_PRIVATE_KEY}
-      - DB_CONNECTION_URL=postgresql://postgres:postgres@postgres-db:5432
-      - FORCE_CHAIN_ID=31337
-      - FORCE_RPC_URL=${RPC_PROVIDER}
-      - FORCE_SMART_CONTRACT_ADDRESS=${FORCE_SMART_CONTRACT_ADDRESS}
+  # funding-service:
+  #   build:
+  #     dockerfile: apps/funding-service/Dockerfile
+  #     context: ../../../
+  #   depends_on:
+  #     - postgres-db
+  #   restart: unless-stopped
+  #   ports:
+  #     - "3010:3010"
+  #   networks:
+  #     - sandbox-proxy
+  #   environment:
+  #     - DEBUG=${DEBUG}
+  #     - PORT=3010
+  #     - SECRET_KEY=${SECRET_KEY}
+  #     - WALLET_PRIV_KEY=${FUNDING_SERVICE_PRIVATE_KEY}
+  #     - DB_CONNECTION_URL=postgresql://postgres:postgres@postgres-db:5432
+  #     - FORCE_CHAIN_ID=31337
+  #     - FORCE_RPC_URL=${RPC_PROVIDER}
+  #     - FORCE_SMART_CONTRACT_ADDRESS=${FORCE_SMART_CONTRACT_ADDRESS}
 
   discovery-platform:
     build:

--- a/devkit/sandbox/src/central-docker-compose.yml
+++ b/devkit/sandbox/src/central-docker-compose.yml
@@ -24,26 +24,26 @@ services:
       - sandbox-proxy
     volumes:
       - postgres-data:/var/lib/postgresql/data
-  funding-service:
-    build:
-      dockerfile: apps/funding-service/Dockerfile
-      context: ../../../
-    depends_on:
-      - postgres-db
-    restart: unless-stopped
-    ports:
-      - "3010:3010"
-    networks:
-      - sandbox-proxy
-    environment:
-      - DEBUG=${DEBUG}
-      - PORT=3010
-      - SECRET_KEY=${SECRET_KEY}
-      - WALLET_PRIV_KEY=${FUNDING_SERVICE_PRIVATE_KEY}
-      - DB_CONNECTION_URL=postgresql://postgres:postgres@postgres-db:5432
-      - FORCE_CHAIN_ID=31337
-      - FORCE_RPC_URL=${RPC_PROVIDER}
-      - FORCE_SMART_CONTRACT_ADDRESS=${FORCE_SMART_CONTRACT_ADDRESS}
+  # funding-service:
+  #   build:
+  #     dockerfile: apps/funding-service/Dockerfile
+  #     context: ../../../
+  #   depends_on:
+  #     - postgres-db
+  #   restart: unless-stopped
+  #   ports:
+  #     - "3010:3010"
+  #   networks:
+  #     - sandbox-proxy
+  #   environment:
+  #     - DEBUG=${DEBUG}
+  #     - PORT=3010
+  #     - SECRET_KEY=${SECRET_KEY}
+  #     - WALLET_PRIV_KEY=${FUNDING_SERVICE_PRIVATE_KEY}
+  #     - DB_CONNECTION_URL=postgresql://postgres:postgres@postgres-db:5432
+  #     - FORCE_CHAIN_ID=31337
+  #     - FORCE_RPC_URL=${RPC_PROVIDER}
+  #     - FORCE_SMART_CONTRACT_ADDRESS=${FORCE_SMART_CONTRACT_ADDRESS}
 
   discovery-platform:
     build:

--- a/devkit/sandbox/src/central-docker-compose.yml
+++ b/devkit/sandbox/src/central-docker-compose.yml
@@ -24,26 +24,6 @@ services:
       - sandbox-proxy
     volumes:
       - postgres-data:/var/lib/postgresql/data
-  # funding-service:
-  #   build:
-  #     dockerfile: apps/funding-service/Dockerfile
-  #     context: ../../../
-  #   depends_on:
-  #     - postgres-db
-  #   restart: unless-stopped
-  #   ports:
-  #     - "3010:3010"
-  #   networks:
-  #     - sandbox-proxy
-  #   environment:
-  #     - DEBUG=${DEBUG}
-  #     - PORT=3010
-  #     - SECRET_KEY=${SECRET_KEY}
-  #     - WALLET_PRIV_KEY=${FUNDING_SERVICE_PRIVATE_KEY}
-  #     - DB_CONNECTION_URL=postgresql://postgres:postgres@postgres-db:5432
-  #     - FORCE_CHAIN_ID=31337
-  #     - FORCE_RPC_URL=${RPC_PROVIDER}
-  #     - FORCE_SMART_CONTRACT_ADDRESS=${FORCE_SMART_CONTRACT_ADDRESS}
 
   discovery-platform:
     build:


### PR DESCRIPTION
This pull request aims to remove funding service container from booting up when starting RPCh locally.

The motivation for this pull request is that Funding Service is not used in sandbox and therefor only takes unnecessary resources.