### PR TITLE
add unregister node endpoint

### DIFF
--- a/apps/discovery-platform/src/db/index.spec.ts
+++ b/apps/discovery-platform/src/db/index.spec.ts
@@ -130,6 +130,16 @@ describe("test db functions", function () {
 
       assert.equal(updatedNode?.status, "UNUSABLE");
     });
+    it("should delete registered node", async function () {
+      const registeredNodeId = "peer1";
+      await db.saveRegisteredNode(dbInstance, createMockNode(registeredNodeId));
+      const node = await db.getRegisteredNode(dbInstance, registeredNodeId);
+      assert.equal(node.id, registeredNodeId);
+      await db.deleteRegisteredNode(dbInstance, registeredNodeId);
+      await expect(
+        db.getRegisteredNode(dbInstance, registeredNodeId)
+      ).rejects.toThrowError();
+    });
   });
   describe("client table", function () {
     it("should create client", async function () {

--- a/apps/discovery-platform/src/db/index.ts
+++ b/apps/discovery-platform/src/db/index.ts
@@ -140,6 +140,18 @@ export const updateRegisteredNode = async (
   }
 };
 
+export const deleteRegisteredNode = async (
+  dbInstance: DBInstance,
+  peerId: string
+): Promise<RegisteredNodeDB> => {
+  const text = `DELETE FROM ${TABLES.REGISTERED_NODES} WHERE id=$<peerId> RETURNING *`;
+  const values = {
+    peerId,
+  };
+  const dbRes: RegisteredNodeDB = await dbInstance.one(text, values);
+
+  return dbRes;
+};
 /**
  * Quota DB functions
  */

--- a/apps/discovery-platform/src/registered-node/index.spec.ts
+++ b/apps/discovery-platform/src/registered-node/index.spec.ts
@@ -6,6 +6,7 @@ import {
   updateRegisteredNode,
   getEligibleNode,
   getRewardForNode,
+  deleteRegisteredNode,
 } from ".";
 import { DBInstance } from "../db";
 import { RegisteredNode } from "../types";
@@ -79,13 +80,18 @@ describe("test registered node functions", function () {
   it("should update registered node", async function () {
     await createRegisteredNode(dbInstance, mockNode("1"));
     const node = await getRegisteredNode(dbInstance, "1");
-    if (!node) throw new Error("Failed to create node");
     await updateRegisteredNode(dbInstance, {
       ...node,
       status: "READY",
     });
     const updatedNode = await getRegisteredNode(dbInstance, "1");
     assert.equal(updatedNode?.status, "READY");
+  });
+  it("should delete registered node", async function () {
+    await createRegisteredNode(dbInstance, mockNode("1"));
+    const node = await getRegisteredNode(dbInstance, "1");
+    await deleteRegisteredNode(dbInstance, node.id);
+    await expect(getRegisteredNode(dbInstance, node.id)).rejects.toThrowError();
   });
   it("should get all nodes that are not exit nodes", async function () {
     await createRegisteredNode(dbInstance, mockNode("1", false));

--- a/apps/discovery-platform/src/registered-node/index.ts
+++ b/apps/discovery-platform/src/registered-node/index.ts
@@ -36,13 +36,27 @@ export const createRegisteredNode = async (
  * Get a specific registered node
  * @param dbInstance DBinstance
  * @param peerId id of the node
- * @returns RegisteredNodeDB | undefined
+ * @returns RegisteredNodeDB
  */
 export const getRegisteredNode = async (
   dbInstance: db.DBInstance,
   peerId: string
 ): Promise<RegisteredNodeDB> => {
   const node = await db.getRegisteredNode(dbInstance, peerId);
+  return node;
+};
+
+/**
+ * Delete a specific registered node
+ * @param dbInstance DBinstance
+ * @param peerId id of the node
+ * @returns RegisteredNodeDB
+ */
+export const deleteRegisteredNode = async (
+  dbInstance: db.DBInstance,
+  peerId: string
+): Promise<RegisteredNodeDB> => {
+  const node = await db.deleteRegisteredNode(dbInstance, peerId);
   return node;
 };
 


### PR DESCRIPTION
## Overview
Adds endpoint `DELETE /request/entry-node/:id` that requires `SECRET` in headers for authentication. This endpoint deletes registered_node from db.