### PR TITLE
Add status filter

### DIFF
--- a/apps/discovery-platform/src/entry-server/routers/v1/index.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/index.ts
@@ -117,7 +117,12 @@ export const v1Router = (ops: {
     checkSchema(getNodeSchema),
     getCache(), // check if response is in cache
     async (
-      req: Request<{}, {}, {}, { excludeList?: string; hasExitNode?: string }>,
+      req: Request<
+        {},
+        {},
+        {},
+        { excludeList?: string; hasExitNode?: string; status?: string }
+      >,
       res: Response
     ) => {
       try {
@@ -128,10 +133,11 @@ export const v1Router = (ops: {
             .inc();
           return res.status(400).json({ errors: errors.array() });
         }
-        const { hasExitNode, excludeList } = req.query;
+        const { hasExitNode, excludeList, status } = req.query;
         const nodes = await getRegisteredNodes(ops.db, {
           excludeList: excludeList?.split(", "),
           hasExitNode: hasExitNode ? hasExitNode === "true" : undefined,
+          status,
         });
         // cache response for 1 min
         setCache(req.originalUrl || req.url, 60e3, nodes);

--- a/apps/discovery-platform/src/entry-server/routers/v1/index.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/index.ts
@@ -22,7 +22,7 @@ import {
   getRegisteredNode,
   getRegisteredNodes,
 } from "../../../registered-node";
-import { ClientDB, RegisteredNode } from "../../../types";
+import { ClientDB, RegisteredNode, RegisteredNodeDB } from "../../../types";
 import { createLogger, isListSafe } from "../../../utils";
 import { errors } from "pg-promise";
 import { MetricManager } from "@rpch/common/build/internal/metric-manager";
@@ -121,7 +121,11 @@ export const v1Router = (ops: {
         {},
         {},
         {},
-        { excludeList?: string; hasExitNode?: string; status?: string }
+        {
+          excludeList?: string;
+          hasExitNode?: string;
+          status?: RegisteredNodeDB["status"];
+        }
       >,
       res: Response
     ) => {

--- a/apps/discovery-platform/src/entry-server/routers/v1/schema.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/schema.ts
@@ -65,7 +65,7 @@ export const registerNodeSchema: Record<keyof RegisteredNode, ParamSchema> = {
 };
 
 export const getNodeSchema: Record<
-  keyof { excludeList?: string; hasExitNode?: string },
+  keyof { excludeList?: string; hasExitNode?: string; status?: string },
   ParamSchema
 > = {
   excludeList: {
@@ -81,5 +81,10 @@ export const getNodeSchema: Record<
     optional: true,
     in: "query",
     isBoolean: true,
+  },
+  status: {
+    optional: true,
+    in: "query",
+    isString: true,
   },
 };

--- a/apps/discovery-platform/src/entry-server/routers/v1/schema.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/schema.ts
@@ -86,5 +86,6 @@ export const getNodeSchema: Record<
     optional: true,
     in: "query",
     isString: true,
+    isIn: { options: [["FRESH", "FUNDING", "UNUSABLE", "READY"]] },
   },
 };


### PR DESCRIPTION
## Overview
adds possible `status` filter to endpoint `/node`

example: 
- `/api/v1/node?status=READY` should respond with all nodes that have status READY
- `/api/v1/node?status=UNUSABLE` should respond with all nodes that have status UNUSABLE
- `/api/v1/node?status=WRONG` should respond with status code 400 and error code