### PR TITLE
exit-node: Pin docker network to specific 172.x.x.x subnet

### DIFF
--- a/apps/exit-node/docker-compose.yml
+++ b/apps/exit-node/docker-compose.yml
@@ -8,6 +8,12 @@ volumes:
 networks:
   hopr-net:
     driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.22.0.0/16
+          gateway: 172.22.0.1
+
 services:
   # hoprd_fluentbit:
   #   image: 'gcr.io/hoprassociation/hopr-fluentbit'


### PR DESCRIPTION
This ensures hoprd nodes identify the network properly and can perform stun requests accordingly.