### PR TITLE
exit-node: Remove wait-for entrypoint in Docker image

### DIFF
--- a/apps/exit-node/Dockerfile
+++ b/apps/exit-node/Dockerfile
@@ -64,11 +64,6 @@ RUN apt-get update && \
   apt-get install -y tini curl wget netcat && \
   rm -rf /var/lib/apt/lists/*
 
-# this helper script can be used to ensure the hoprd node is running before starting
-RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /bin/wait-for-it.sh \
-  && chmod o+x /bin/wait-for-it.sh \
-  && chmod u+x /bin/wait-for-it.sh
-
 COPY --from=installer /app/apps/exit-node/package.json .
 COPY --from=installer /app .
 

--- a/apps/exit-node/docker-compose.yml
+++ b/apps/exit-node/docker-compose.yml
@@ -106,17 +106,6 @@ services:
       - RPCH_PRIVATE_KEY=${RPCH_PRIVATE_KEY}
       - RPCH_DATA_DIR=${RPCH_DATA_DIR}
       - OPT_IN_METRICS=${OPT_IN_METRICS}
-    entrypoint:
-      [
-        "/bin/wait-for-it.sh",
-        "http://${HOPRD_API_TOKEN}@hoprd:3001/api/v2/account/addresses",
-        "-t",
-        "300",
-        "--",
-        "/usr/bin/tini",
-        "--",
-      ]
-    command: "node apps/exit-node/build/index.js"
     networks:
       - hopr-net
     logging:


### PR DESCRIPTION
The wait for logic will never succeed since the tool cannot work with HTTP basic auth. Its also obsolete since the exit-node can either retry if HOPRd is not available or the Docker container can restart until the API is available.

Fixes https://github.com/Rpc-h/RPCh/issues/379