### PR TITLE
exit-node: Remove wait-for entrypoint in Docker image

### DIFF
--- a/apps/exit-node/Dockerfile
+++ b/apps/exit-node/Dockerfile
@@ -64,11 +64,6 @@ RUN apt-get update && \
   apt-get install -y tini curl wget netcat && \
   rm -rf /var/lib/apt/lists/*
 
-# this helper script can be used to ensure the hoprd node is running before starting
-RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /bin/wait-for-it.sh \
-  && chmod o+x /bin/wait-for-it.sh \
-  && chmod u+x /bin/wait-for-it.sh
-
 COPY --from=installer /app/apps/exit-node/package.json .
 COPY --from=installer /app .
 

--- a/apps/exit-node/docker-compose.yml
+++ b/apps/exit-node/docker-compose.yml
@@ -106,17 +106,6 @@ services:
       - RPCH_PRIVATE_KEY=${RPCH_PRIVATE_KEY}
       - RPCH_DATA_DIR=${RPCH_DATA_DIR}
       - OPT_IN_METRICS=${OPT_IN_METRICS}
-    entrypoint:
-      [
-        "/bin/wait-for-it.sh",
-        "http://${HOPRD_API_TOKEN}@hoprd:3001/api/v2/account/addresses",
-        "-t",
-        "300",
-        "--",
-        "/usr/bin/tini",
-        "--",
-      ]
-    command: "node apps/exit-node/build/index.js"
     networks:
       - hopr-net
     logging:

--- a/devkit/sandbox/src/nodes-docker-compose.yml
+++ b/devkit/sandbox/src/nodes-docker-compose.yml
@@ -59,16 +59,6 @@ services:
       - DEBUG=${DEBUG:-"rpch*"}
       - HOPRD_API_TOKEN=${HOPRD_API_TOKEN}
       - RPCH_PRIVATE_KEY=${EXIT_NODE_PRIV_KEY_1}
-    entrypoint:
-      [
-        "/bin/wait-for-it.sh",
-        "http://${HOPRD_API_TOKEN}@pluto:13301/api/v2/account/addresses",
-        "-t",
-        "15",
-        "--",
-        "/usr/bin/tini",
-        "--",
-      ]
   exit-2:
     <<: *exit
     environment:
@@ -77,16 +67,6 @@ services:
       - OPT_IN_METRICS=${OPT_IN_METRICS}
       - HOPRD_API_TOKEN=${HOPRD_API_TOKEN}
       - RPCH_PRIVATE_KEY=${EXIT_NODE_PRIV_KEY_2}
-    entrypoint:
-      [
-        "/bin/wait-for-it.sh",
-        "http://${HOPRD_API_TOKEN}@pluto:13302/api/v2/account/addresses",
-        "-t",
-        "15",
-        "--",
-        "/usr/bin/tini",
-        "--",
-      ]
   exit-3:
     <<: *exit
     environment:
@@ -95,16 +75,6 @@ services:
       - HOPRD_API_TOKEN=${HOPRD_API_TOKEN}
       - OPT_IN_METRICS=${OPT_IN_METRICS}
       - RPCH_PRIVATE_KEY=${EXIT_NODE_PRIV_KEY_3}
-    entrypoint:
-      [
-        "/bin/wait-for-it.sh",
-        "http://${HOPRD_API_TOKEN}@pluto:13303/api/v2/account/addresses",
-        "-t",
-        "15",
-        "--",
-        "/usr/bin/tini",
-        "--",
-      ]
   exit-4:
     <<: *exit
     environment:
@@ -113,16 +83,6 @@ services:
       - HOPRD_API_TOKEN=${HOPRD_API_TOKEN}
       - OPT_IN_METRICS=${OPT_IN_METRICS}
       - RPCH_PRIVATE_KEY=${EXIT_NODE_PRIV_KEY_4}
-    entrypoint:
-      [
-        "/bin/wait-for-it.sh",
-        "http://${HOPRD_API_TOKEN}@pluto:13304/api/v2/account/addresses",
-        "-t",
-        "15",
-        "--",
-        "/usr/bin/tini",
-        "--",
-      ]
   exit-5:
     <<: *exit
     environment:
@@ -131,16 +91,6 @@ services:
       - HOPRD_API_TOKEN=${HOPRD_API_TOKEN}
       - OPT_IN_METRICS=${OPT_IN_METRICS}
       - RPCH_PRIVATE_KEY=${EXIT_NODE_PRIV_KEY_5}
-    entrypoint:
-      [
-        "/bin/wait-for-it.sh",
-        "http://${HOPRD_API_TOKEN}@pluto:13305/api/v2/account/addresses",
-        "-t",
-        "15",
-        "--",
-        "/usr/bin/tini",
-        "--",
-      ]
 
 # since this file is run first,
 # we create the sandbox network


### PR DESCRIPTION
The wait for logic will never succeed since the tool cannot work with HTTP basic auth. Its also obsolete since the exit-node can either retry if HOPRd is not available or the Docker container can restart until the API is available.