### PR TITLE
Revert "Fix incorrect segmentation for non-ASCII characters (#386)"

### DIFF
--- a/packages/common/src/utils/index.spec.ts
+++ b/packages/common/src/utils/index.spec.ts
@@ -17,29 +17,13 @@ import { req_80kb } from "../compression/compression-samples";
 describe("test utils / splitStrByBytes", function () {
   it("should return 1 string", function () {
     const str = "helloworld";
-
-    const res = splitStrByBytes(str, 10);
-    const expected = ["helloworld"];
-
-    assert(res.every((str, i) => expected[i] === str));
+    assert.equal(utils.toUtf8Bytes(str).byteLength, 10);
+    assert.equal(splitStrByBytes(str, 10).length, 1);
   });
   it("should return 3 strings", function () {
     const str = "helloworldhelloworldhelloworld";
-
     assert.equal(utils.toUtf8Bytes(str).byteLength, 30);
-
-    const res = splitStrByBytes(str, 10);
-    const expected = ["helloworld", "helloworld", "helloworld"];
-
-    assert(res.every((str, i) => expected[i] === str));
-  });
-  it("should respect Utf-8 character sizes", function () {
-    const str = "A𝑨B𝑩C𝑪";
-
-    const res = splitStrByBytes(str, 2);
-    const expected = ["A", "𝑨", "B", "𝑩", "C", "𝑪"];
-
-    assert(res.every((str, i) => expected[i] === str));
+    assert.equal(splitStrByBytes(str, 10).length, 3);
   });
 });
 

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -11,31 +11,19 @@ export const createLogger = LoggerFactory("common");
 export const MAX_BYTES = 400;
 
 /**
- * Split string such that its byte representation does not
- * exceed maxBytes
+ * Split string by bytes.
  * @param str
  * @param maxBytes
  * @returns splitted string
  */
 export const splitStrByBytes = (str: string, maxBytes: number): string[] => {
+  let arr = utils.toUtf8Bytes(str);
   const res: string[] = [];
 
-  let offset = 0;
-  let current = "";
-
-  for (let utf8char of str) {
-    if (offset + utf8char.length > maxBytes) {
-      res.push(current);
-      offset = 0;
-      current = "";
-    }
-
-    offset += utf8char.length;
-    current += utf8char;
-  }
-
-  if (current.length > 0) {
-    res.push(current);
+  while (arr.length > 0) {
+    const index = arr.length > maxBytes ? maxBytes : arr.length;
+    res.push(utils.toUtf8String(arr.slice(0, index)));
+    arr = arr.slice(index, arr.length);
   }
 
   return res;


### PR DESCRIPTION
This reverts commit 6c5f475c7b720c7885b6db2151411d8b54d38c5d.

This changing is backwards incompatible, will be added in a major release.