### PR TITLE
Reduce complexity during entry node selection by removing unused deadlock functionality

### DIFF
--- a/apps/rpc-server/src/index.spec.ts
+++ b/apps/rpc-server/src/index.spec.ts
@@ -64,28 +64,4 @@ describe("test index.ts", function () {
     const json = JSON.parse(response.text);
     assert.equal(json.result, "0x17f88c8");
   });
-
-  describe("should respond even when deadlocked", function () {
-    it("sdk is deadlocked", async function () {
-      rpcServer.sdk?.setDeadlock(10000);
-      const res = await request
-        .post("/?exit-provider=someprovider")
-        .send(JSON.stringify({ id: "1", method: "eth_chainId" }))
-        .expect(200);
-
-      const json = JSON.parse(res.text);
-      assert.equal(json.result, "0x01");
-      rpcServer.sdk?.setDeadlock(0);
-    });
-    it("sdk not initialized", async function () {
-      const temp = rpcServer.sdk!;
-      rpcServer.sdk = undefined;
-      const res = await request
-        .post("/?exit-provider=someprovider")
-        .send(JSON.stringify({ id: "1", method: "eth_chainId" }));
-
-      expect(res.text).toContain("SDK not initialized");
-      rpcServer.sdk = mockSdk(temp);
-    });
-  });
 });

--- a/devkit/e2e/src/start.sh
+++ b/devkit/e2e/src/start.sh
@@ -18,8 +18,6 @@ trap 'stop; exit 1' SIGINT SIGKILL SIGTERM ERR
 # start sandbox
 start
 
-sleep 60
-
 # Run tests with env variables
 npx jest --ci || exit 1
 

--- a/devkit/e2e/src/start.sh
+++ b/devkit/e2e/src/start.sh
@@ -18,6 +18,8 @@ trap 'stop; exit 1' SIGINT SIGKILL SIGTERM ERR
 # start sandbox
 start
 
+sleep 60
+
 # Run tests with env variables
 npx jest --ci || exit 1
 

--- a/packages/sdk/src/index.spec.ts
+++ b/packages/sdk/src/index.spec.ts
@@ -361,35 +361,6 @@ describe("test SDK class", function () {
       ).rejects.toThrow();
     });
 
-    it("should not allow creating a request if sdk is deadlocked", async function () {
-      sdk.setDeadlock(10e6);
-      try {
-        await sdk.createRequest(fixtures.PROVIDER, fixtures.RPC_REQ_LARGE);
-      } catch (e: any) {
-        expect(e.message).toMatch("SDK is deadlocked");
-      }
-    });
-
-    it("should allow sending requests if sdk is deadlocked", async function () {
-      sdk.setDeadlock(10e6);
-      HOPRD_SEND_MESSAGE_NOCK.reply(202, "someresponse");
-
-      const [clientRequest, , exitNodeResponse] =
-        await fixtures.generateMockedFlow(3);
-
-      sdk.sendRequest(clientRequest).then((response) => {
-        // this will run when .onMessage resolves request
-        assert.equal(response.id, clientRequest.id);
-        // @ts-ignore
-        const pendingRequest = sdk.requestCache.getRequest(clientRequest.id);
-        assert.equal(pendingRequest, undefined);
-      });
-
-      // return response for sdk sendRequest
-      // @ts-ignore
-      sdk.onMessage(exitNodeResponse.toMessage());
-    });
-
     it("should handle failed request", async function () {
       HOPRD_SEND_MESSAGE_NOCK.reply(400, "error");
       const [clientRequest] = await fixtures.generateMockedFlow(3);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -19,6 +19,7 @@ import { createLogger } from "./utils";
 const log = createLogger();
 const DEFAULT_MAXIMUM_SEGMENTS_PER_REQUEST = 10;
 const DEFAULT_RESET_NODE_METRICS_MS = 1e3 * 60 * 5; // 5 min
+const DEFAULT_ENTRY_NODE_SELECTION_TIMEOUT = 1e3 * 5; // 5 sec
 const DEFAULT_MINIMUM_SCORE_FOR_RELIABLE_NODE = 0.8;
 const DEFAULT_RELIABILITY_SCORE_FRESH_NODE_THRESHOLD = 10;
 const DEFAULT_RELIABILITY_SCORE_MAX_RESPONSES = 100;
@@ -180,7 +181,7 @@ export default class SDK {
       );
 
       // get new entry nodes
-      let entryNodes: EntryNode[] = Array.from(this.entryNodes.values());
+      const entryNodes: EntryNode[] = Array.from(this.entryNodes.values());
       for (let i = 0; i < amountNeeded; i++) {
         const excludeList: string[] = [
           ...brokenNodes,
@@ -518,7 +519,7 @@ export default class SDK {
 
           // reset old nodes from reliability score
           this.reliabilityScore.resetOldNodeMetrics(this.resetNodeMetricsMs);
-        }, 1e3 * 5) // look for entry nodes every 5 seconds - TODO
+        }, DEFAULT_ENTRY_NODE_SELECTION_TIMEOUT) // look for entry nodes every 5 seconds
       );
 
       this.intervals.push(

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -19,7 +19,6 @@ import { createLogger } from "./utils";
 const log = createLogger();
 const DEFAULT_MAXIMUM_SEGMENTS_PER_REQUEST = 10;
 const DEFAULT_RESET_NODE_METRICS_MS = 1e3 * 60 * 5; // 5 min
-const DEFAULT_DEADLOCK_MS = 1e3 * 5; // 5s
 const DEFAULT_MINIMUM_SCORE_FOR_RELIABLE_NODE = 0.8;
 const DEFAULT_RELIABILITY_SCORE_FRESH_NODE_THRESHOLD = 10;
 const DEFAULT_RELIABILITY_SCORE_MAX_RESPONSES = 100;
@@ -34,8 +33,6 @@ const MAX_REQUEST_TIMEOUT = 1e3 * 30; // 30 sec
  * @param timeout The timeout of pending requests
  * @param maximumSegmentsPerRequest Optional: Blocks requests that are made up of more than 10 segments
  * @param resetNodeMetricsMs Optional: Reset score metrics after specifies miliseconds
- * @param deadlockMs Optional: How long to pause the SDK before sending more requests to the discovery platform after an error
- * @param disableDeadlock Optional: Disable deadlocking
  * @param minimumScoreForReliableNode Optional: Nodes with lower score than this will be swapped for new ones
  * @param maxEntryNodes Optional: How many entry nodes to use in parallel
  * @param reliabilityScoreFreshNodeThreshold Optional: The score which is considered fresh for a node
@@ -50,8 +47,6 @@ export type HoprSdkOps = {
   timeout: number;
   maximumSegmentsPerRequest?: number;
   resetNodeMetricsMs?: number;
-  deadlockMs?: number;
-  disableDeadlock?: boolean;
   minimumScoreForReliableNode?: number;
   maxEntryNodes?: number;
   reliabilityScoreFreshNodeThreshold?: number;
@@ -86,7 +81,6 @@ export default class SDK {
   private maximumSegmentsPerRequest: number =
     DEFAULT_MAXIMUM_SEGMENTS_PER_REQUEST;
   private resetNodeMetricsMs: number = DEFAULT_RESET_NODE_METRICS_MS;
-  private deadlockMs: number = DEFAULT_DEADLOCK_MS;
   private minimumScoreForReliableNode: number =
     DEFAULT_MINIMUM_SCORE_FOR_RELIABLE_NODE;
   private maxEntryNodes: number = DEFAULT_MAX_ENTRY_NODES;
@@ -101,8 +95,6 @@ export default class SDK {
   private segmentCache: SegmentCache;
   private requestCache: RequestCache;
   private selectingEntryNodes: boolean = false;
-  // an epoch timestamp that halts selecting new entry nodes
-  public deadlockTimestamp: number | undefined;
   // keeps track a reliability score for every entry-node used
   private reliabilityScore: ReliabilityScore;
   // allows developers to programmatically enable debugging
@@ -136,7 +128,6 @@ export default class SDK {
       ops.maximumSegmentsPerRequest ?? DEFAULT_MAXIMUM_SEGMENTS_PER_REQUEST;
     this.resetNodeMetricsMs =
       ops.resetNodeMetricsMs ?? DEFAULT_RESET_NODE_METRICS_MS;
-    this.deadlockMs = ops.deadlockMs ?? DEFAULT_DEADLOCK_MS;
     this.minimumScoreForReliableNode =
       ops.minimumScoreForReliableNode ??
       DEFAULT_MINIMUM_SCORE_FOR_RELIABLE_NODE;
@@ -160,9 +151,8 @@ export default class SDK {
   ): Promise<void> {
     log.normal("selectEntryNodes", {
       selectingEntryNodes: this.selectingEntryNodes,
-      deadlocked: this.isDeadlocked(),
     });
-    if (this.selectingEntryNodes || this.isDeadlocked()) return;
+    if (this.selectingEntryNodes) return;
 
     try {
       this.selectingEntryNodes = true;
@@ -190,13 +180,13 @@ export default class SDK {
       );
 
       // get new entry nodes
-      let entryNodes: EntryNode[] = [];
+      let entryNodes: EntryNode[] = Array.from(this.entryNodes.values());
       for (let i = 0; i < amountNeeded; i++) {
         const excludeList: string[] = [
           ...brokenNodes,
           ...entryNodes.map((e) => e.peerId),
         ];
-        const entryNode = await retry(
+        await retry(
           async () => {
             return this.selectEntryNode(
               discoveryPlatformApiEndpoint,
@@ -212,11 +202,9 @@ export default class SDK {
             maxTimeout: MAX_REQUEST_TIMEOUT,
           }
         );
-        entryNodes.push(entryNode);
       }
     } catch (error) {
       log.error("Couldn't find new entry node: ", error);
-      if (!this.ops.disableDeadlock) this.setDeadlock(this.deadlockMs);
       throw error;
     } finally {
       this.selectingEntryNodes = false;
@@ -530,7 +518,7 @@ export default class SDK {
 
           // reset old nodes from reliability score
           this.reliabilityScore.resetOldNodeMetrics(this.resetNodeMetricsMs);
-        }, 1e3)
+        }, 1e3 * 5) // look for entry nodes every 5 seconds - TODO
       );
 
       this.intervals.push(
@@ -632,30 +620,6 @@ export default class SDK {
       exitNode.peerId,
       this.crypto!.Identity.load_identity(etherUtils.arrayify(exitNode.pubKey))
     );
-  }
-
-  /**
-   * Checks if sdk should be in deadlock
-   * @returns boolean
-   */
-  private isDeadlocked(): boolean {
-    if (!this.deadlockTimestamp) return false;
-    const now = Date.now();
-    if (now < this.deadlockTimestamp) {
-      log.verbose("SDK is deadlocked until", this.deadlockTimestamp);
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * Sets timestamp by adding time now and received parameter
-   * @param timeInMs number
-   */
-  public setDeadlock(timeInMs: number): void {
-    const now = Date.now();
-    this.deadlockTimestamp = timeInMs + now;
-    log.verbose("new deadlock timestamp", this.deadlockTimestamp);
   }
 
   /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -19,11 +19,11 @@ import { createLogger } from "./utils";
 const log = createLogger();
 const DEFAULT_MAXIMUM_SEGMENTS_PER_REQUEST = 10;
 const DEFAULT_RESET_NODE_METRICS_MS = 1e3 * 60 * 5; // 5 min
-const DEFAULT_ENTRY_NODE_SELECTION_TIMEOUT = 1e3 * 5; // 5 sec
 const DEFAULT_MINIMUM_SCORE_FOR_RELIABLE_NODE = 0.8;
 const DEFAULT_RELIABILITY_SCORE_FRESH_NODE_THRESHOLD = 10;
 const DEFAULT_RELIABILITY_SCORE_MAX_RESPONSES = 100;
 const DEFAULT_MAX_ENTRY_NODES = 2;
+const ENTRY_NODE_SELECTION_TIMEOUT = 1e3 * 5; // 5 sec
 const MAX_REQUEST_TIMEOUT = 1e3 * 30; // 30 sec
 
 /**
@@ -519,7 +519,7 @@ export default class SDK {
 
           // reset old nodes from reliability score
           this.reliabilityScore.resetOldNodeMetrics(this.resetNodeMetricsMs);
-        }, DEFAULT_ENTRY_NODE_SELECTION_TIMEOUT) // look for entry nodes every 5 seconds
+        }, ENTRY_NODE_SELECTION_TIMEOUT) // look for entry nodes every 5 seconds
       );
 
       this.intervals.push(


### PR DESCRIPTION
This removes the unused deadlock mechanic to avoid deadlocking node selection trigger.

Also fixed minor node selection logic bug where current nodes where not excluding from the request to the discovery platform.

Related https://github.com/Rpc-h/RPCh/issues/421