### PR TITLE
Fix node selection running stale

### DIFF
--- a/apps/discovery-platform/src/funding-service-api/index.ts
+++ b/apps/discovery-platform/src/funding-service-api/index.ts
@@ -14,6 +14,7 @@ import { createFundingRequest } from "../funding-request";
 import retry from "async-retry";
 
 const log = createLogger(["funding-service-api"]);
+const DEFAULT_MAX_REQUEST_TIMEOUT = 1e3 * 30; // 30 sec
 
 /**
  * API used to fund registered nodes, handles creating and keeping track of pending requests.
@@ -334,6 +335,7 @@ export class FundingServiceApi {
       },
       {
         retries: 3,
+        maxTimeout: DEFAULT_MAX_REQUEST_TIMEOUT,
         ...opts,
       }
     );

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -24,6 +24,7 @@ const DEFAULT_MINIMUM_SCORE_FOR_RELIABLE_NODE = 0.8;
 const DEFAULT_RELIABILITY_SCORE_FRESH_NODE_THRESHOLD = 10;
 const DEFAULT_RELIABILITY_SCORE_MAX_RESPONSES = 100;
 const DEFAULT_MAX_ENTRY_NODES = 2;
+const MAX_REQUEST_TIMEOUT = 1e3 * 30; // 30 sec
 
 /**
  * HOPR SDK options.
@@ -208,6 +209,7 @@ export default class SDK {
               log.error("Error while selecting entry node", e);
               log.verbose("Retrying to select entry node, attempt:", attempt);
             },
+            maxTimeout: MAX_REQUEST_TIMEOUT,
           }
         );
         entryNodes.push(entryNode);
@@ -504,6 +506,7 @@ export default class SDK {
             log.error("Error while fetching exit nodes", e);
             log.verbose("Retrying to fetch exit nodes, attempt:", attempt);
           },
+          maxTimeout: MAX_REQUEST_TIMEOUT,
         }
       );
 


### PR DESCRIPTION
Looking at the logs it became clear that node selection will run into an infinite loop.
Most probably this happens during some of the fetch request that it does.

Since `fetch` seems to have a decent default timeout the only location remaining is `async-retry`.
This indeed has a default timeout of `Infinity`. Fixing that we hope to fix this issue.