### PR TITLE
Deploy rp cserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,18 @@ Checkout [Sandbox](https://github.com/Rpc-h/RPCh/tree/main/devkit/sandbox#sandbo
 
 ### For developers
 
-- coverage: currently we can generate coverage reports for each project, but we do not have a threshold set in which we would fail our CI
-- dependency check: we currently use `check-dependency-version-consistency` to ensure consistency between the dependency version, future plan is to use `depcheck` for every project to ensure all libraries are correctly added per `package.json`
+- coverage: currently we can generate coverage reports for each project,
+  but we do not have a threshold set in which we would fail our CI
+- dependency check: we currently use `check-dependency-version-consistency` to ensure consistency between the dependency version,
+  future plan is to use `depcheck` for every project to ensure all libraries are correctly added per `package.json`
+
+## Deployment
+
+Deployment works mostly automated.
+Whenever changes are pushed/merged to the `main` branch, the CI system will automatically check
+
+- if it can build new application container images
+- if it can publish new npm packages
+
+If an application/package depends on a newer package version from npm,
+ASK Martins

--- a/apps/rpc-server/package.json
+++ b/apps/rpc-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpch/rpc-server",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "license": "LGPL-3.0",
   "private": true,
   "scripts": {

--- a/apps/rpc-server/package.json
+++ b/apps/rpc-server/package.json
@@ -24,8 +24,8 @@
     "supertest": "^6.3.3"
   },
   "dependencies": {
-    "@rpch/sdk": "0.2.3",
     "@rpch/crypto-for-nodejs": "0.3.4",
+    "@rpch/sdk": "file:packages/sdk",
     "leveldown": "^6.1.1",
     "levelup": "^5.1.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1709,6 +1709,14 @@
   resolved "https://registry.yarnpkg.com/@rpch/crypto/-/crypto-0.3.4.tgz#201b8e5f0efc7ffb8d3d06f210f5eebd04d41acd"
   integrity sha512-429mUQce5wbAIEHtg1yd9MyEcj8fqxixoDh0msZnVrynhzgFbkyTEHYjBUsj9XHLsyBnMUgzWZGogim8/cR0jw==
 
+"@rpch/sdk@file:packages/sdk":
+  version "0.2.3"
+  dependencies:
+    "@rpch/common" "0.2.3"
+    async-retry "^1.3.3"
+    cross-fetch "3.2.0-alpha.2"
+    ethers "^5.7.2"
+
 "@rushstack/eslint-patch@^1.1.3":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"


### PR DESCRIPTION
Circumvent npm js publishing for new version of rpc-server for now.