### PR TITLE
Make deployed application versions use same dependencies as specified in yarn.lock

### DIFF
--- a/apps/availability-monitor/Dockerfile
+++ b/apps/availability-monitor/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /app
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/yarn.lock ./yarn.lock
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 # Build the project.
 COPY --from=builder /app/out/full .

--- a/apps/availability-monitor/Dockerfile
+++ b/apps/availability-monitor/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /app
 # Install the dependencies.
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
-COPY --from=builder /app/out/yarn.lock .yarn.lock
+COPY --from=builder /app/out/yarn.lock ./yarn.lock
 RUN yarn install
 
 # Build the project.

--- a/apps/discovery-platform/Dockerfile
+++ b/apps/discovery-platform/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /app
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/yarn.lock ./yarn.lock
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 # Build the project.
 COPY --from=builder /app/out/full .

--- a/apps/discovery-platform/Dockerfile
+++ b/apps/discovery-platform/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /app
 # Install the dependencies.
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
-COPY --from=builder /app/out/yarn.lock .yarn.lock
+COPY --from=builder /app/out/yarn.lock ./yarn.lock
 RUN yarn install
 
 # Build the project.

--- a/apps/exit-node/Dockerfile
+++ b/apps/exit-node/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR /app
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/yarn.lock ./yarn.lock
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 # Build the project.
 COPY --from=builder /app/out/full .

--- a/apps/exit-node/Dockerfile
+++ b/apps/exit-node/Dockerfile
@@ -41,7 +41,7 @@ WORKDIR /app
 # Install the dependencies.
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
-COPY --from=builder /app/out/yarn.lock .yarn.lock
+COPY --from=builder /app/out/yarn.lock ./yarn.lock
 RUN yarn install
 
 # Build the project.

--- a/apps/funding-service/Dockerfile
+++ b/apps/funding-service/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /app
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/yarn.lock ./yarn.lock
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 # Build the project.
 COPY --from=builder /app/out/full .

--- a/apps/funding-service/Dockerfile
+++ b/apps/funding-service/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /app
 # Install the dependencies.
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
-COPY --from=builder /app/out/yarn.lock .yarn.lock
+COPY --from=builder /app/out/yarn.lock ./yarn.lock
 RUN yarn install
 
 # Build the project.

--- a/apps/rpc-server/Dockerfile
+++ b/apps/rpc-server/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR /app
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/yarn.lock ./yarn.lock
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 # Build the project.
 COPY --from=builder /app/out/full .

--- a/apps/rpc-server/Dockerfile
+++ b/apps/rpc-server/Dockerfile
@@ -41,7 +41,7 @@ WORKDIR /app
 # Install the dependencies.
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
-COPY --from=builder /app/out/yarn.lock .yarn.lock
+COPY --from=builder /app/out/yarn.lock ./yarn.lock
 RUN yarn install
 
 # Build the project.


### PR DESCRIPTION
There was a minor typo which would cause the build system to not use `yarn.lock` at all.

This change should have no effect on our current applications.