### PR TITLE
Fix image tag generation to refer to the SHA that triggered the workflow

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Calculate environment variables
         shell: sh
-        run: echo "SHORT_SHA=`git rev-parse --short HEAD`" >> $GITHUB_ENV
+        run: echo "SHORT_SHA=`echo $GITHUB_SHA | cut -c1-7`" >> $GITHUB_ENV
 
       - name: Login to GCP
         id: gcloud


### PR DESCRIPTION
Fix image tag generation to refer to the SHA that triggered the workflow.