### PR TITLE
Fix exclude list filter in Discovery platform

### DIFF
--- a/apps/discovery-platform/src/db/index.ts
+++ b/apps/discovery-platform/src/db/index.ts
@@ -38,15 +38,15 @@ export const getRegisteredNodes = async (
   log.verbose("Querying for Registered nodes with filters", filters);
   let baseText = `SELECT * FROM ${TABLES.REGISTERED_NODES}`;
   let filtersText = [];
-  const values: { [key: string]: string } = {};
+  const values: { [key: string]: string | string[] } = {};
 
   if (filters?.excludeList !== undefined && filters.excludeList.length !== 0) {
-    filtersText.push("id NOT IN ($<list>)");
-    values["list"] = filters.excludeList.join(", ");
+    filtersText.push("id NOT IN ($<list:csv>)");
+    values["list"] = filters.excludeList;
   }
   if (filters?.includeList !== undefined && filters.includeList.length !== 0) {
-    filtersText.push("id IN ($<list>)");
-    values["list"] = filters.includeList.join(", ");
+    filtersText.push("id IN ($<list:csv>)");
+    values["list"] = filters.includeList;
   }
   if (filters?.hasExitNode !== undefined) {
     filtersText.push("has_exit_node=$<exitNode>");
@@ -60,7 +60,7 @@ export const getRegisteredNodes = async (
   const sqlText = filtersText.length
     ? baseText + " WHERE " + filtersText.join(" AND ")
     : baseText;
-
+  console.log(sqlText, filtersText, values);
   const dbRes: RegisteredNodeDB[] = await dbInstance.manyOrNone(
     sqlText,
     values

--- a/apps/discovery-platform/src/db/index.ts
+++ b/apps/discovery-platform/src/db/index.ts
@@ -60,7 +60,7 @@ export const getRegisteredNodes = async (
   const sqlText = filtersText.length
     ? baseText + " WHERE " + filtersText.join(" AND ")
     : baseText;
-  console.log(sqlText, filtersText, values);
+
   const dbRes: RegisteredNodeDB[] = await dbInstance.manyOrNone(
     sqlText,
     values

--- a/apps/discovery-platform/src/db/index.ts
+++ b/apps/discovery-platform/src/db/index.ts
@@ -40,6 +40,8 @@ export const getRegisteredNodes = async (
   let filtersText = [];
   const values: { [key: string]: string | string[] } = {};
 
+  // using :csv formats an array to a comma separated list
+  // source https://github.com/vitaly-t/pg-promise#csv-filter
   if (filters?.excludeList !== undefined && filters.excludeList.length !== 0) {
     filtersText.push("id NOT IN ($<list:csv>)");
     values["list"] = filters.excludeList;
@@ -65,6 +67,7 @@ export const getRegisteredNodes = async (
     sqlText,
     values
   );
+
   log.verbose(
     "Registered nodes with filters query DB response",
     filters,

--- a/apps/discovery-platform/src/entry-server/routers/v1/index.spec.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/index.spec.ts
@@ -566,7 +566,7 @@ describe("test v1 router", function () {
         errors: "Could not find eligible node",
       });
     });
-    it.only("should return an entry node when adding recently received node was put on the exclude list in a subsequent call", async function () {
+    it("should return an entry node when adding recently received node was put on the exclude list in a subsequent call", async function () {
       const amountLeft = BigInt(10).toString();
       const peerId = "entry";
       const secondPeerId = "secondEntry";

--- a/apps/discovery-platform/src/entry-server/routers/v1/index.spec.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/index.spec.ts
@@ -561,7 +561,6 @@ describe("test v1 router", function () {
         .set("X-Rpch-Client", trialClientId)
         .send({ excludeList: [peerId, secondPeerId] });
 
-      console.log({ requestResponse });
       assert.equal(requestResponse.status, 404);
       assert.deepEqual(requestResponse.body, {
         errors: "Could not find eligible node",

--- a/apps/discovery-platform/src/entry-server/routers/v1/index.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/index.ts
@@ -396,7 +396,10 @@ export const v1Router = (ops: {
     metricMiddleware(requestDurationHistogram),
     body("excludeList")
       .optional()
-      .custom((value) => isListSafe(value)),
+      .isArray()
+      .withMessage("Must be an array")
+      .custom((arr) => arr.every((item: unknown) => typeof item === "string"))
+      .withMessage("Every item in the array must be a string"),
     async (req, res) => {
       try {
         const errors = validationResult(req);
@@ -445,8 +448,10 @@ export const v1Router = (ops: {
         //   });
         // }
 
+        console.log({ excludeList });
         // expand 'excludeList' with unstable nodes
         const unstableNodes = getUnstableNodes();
+        console.log({ unstableNodes });
         if (unstableNodes.length > 0) {
           log.verbose(
             "We have unstable nodes %i, adding to 'excludeList'",
@@ -515,7 +520,10 @@ export const v1Router = (ops: {
     metricMiddleware(requestDurationHistogram),
     body("excludeList")
       .optional()
-      .custom((value) => isListSafe(value)),
+      .isArray()
+      .withMessage("Must be an array")
+      .custom((arr) => arr.every((item: unknown) => typeof item === "string"))
+      .withMessage("Every item in the array must be a string"),
     body("amount").optional().isInt({ min: 1, max: 10 }),
     async (req, res) => {
       try {

--- a/apps/discovery-platform/src/entry-server/routers/v1/index.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/index.ts
@@ -448,10 +448,8 @@ export const v1Router = (ops: {
         //   });
         // }
 
-        console.log({ excludeList });
         // expand 'excludeList' with unstable nodes
         const unstableNodes = getUnstableNodes();
-        console.log({ unstableNodes });
         if (unstableNodes.length > 0) {
           log.verbose(
             "We have unstable nodes %i, adding to 'excludeList'",

--- a/apps/discovery-platform/src/registered-node/index.ts
+++ b/apps/discovery-platform/src/registered-node/index.ts
@@ -87,6 +87,7 @@ export const getEligibleNode = async (
     ...filters,
     status: "READY",
   });
+  console.log({ readyNodes });
   if (readyNodes.length) {
     // choose selected entry node
     const selectedNode = utils.randomlySelectFromArray(readyNodes);

--- a/apps/discovery-platform/src/registered-node/index.ts
+++ b/apps/discovery-platform/src/registered-node/index.ts
@@ -87,7 +87,6 @@ export const getEligibleNode = async (
     ...filters,
     status: "READY",
   });
-  console.log({ readyNodes });
   if (readyNodes.length) {
     // choose selected entry node
     const selectedNode = utils.randomlySelectFromArray(readyNodes);


### PR DESCRIPTION
### overview
This pr fixes filter `excludeList` in discovery platform POST endpoints.

#### middleware changes
Before we would check `excludeList` that was being sent in the body with the util function `isListSafe` which actually checks if a string only contains commas and dashes and underscores. In this case we are sending an array so this check was not actually working and has been updated to check if all array entries are string

#### db changes
After doing the middleware changes I could observe that the database excludeList filter was not acting as a list but rather as a really long id. So I updated the query to use the a csv filter that separates arrays with commas [source](https://github.com/vitaly-t/pg-promise#csv-filter)

#### other test changes
- the unstable id was not working because we check if peerIds are alphanumeric so I removed the underscores.
- updated entry node exclude list tests so it does not **randomly** pass. 
