### PR TITLE
specify publish config

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -41,5 +41,8 @@
     "msgpackr": "^1.8.5",
     "peer-id": "^0.16.0",
     "ws": "^8.11.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/ethereum-provider/package.json
+++ b/packages/ethereum-provider/package.json
@@ -23,5 +23,8 @@
     "@rpch/sdk": "0.5.2",
     "ethereum-provider": "^0.7.7",
     "events": "^3.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -26,5 +26,8 @@
   },
   "peerDependencies": {
     "ethers": "^5.7.2"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -26,5 +26,8 @@
     "@rpch/common": "0.4.0",
     "async-retry": "^1.3.3",
     "ethers": "^5.7.2"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Specify that our packages should be published publically, without it `npx changeset publish` does not work