### PR TITLE
Allow RPCh usage from Firefox, fix default MEV protection settings

### DIFF
--- a/.changeset/chatty-pans-agree.md
+++ b/.changeset/chatty-pans-agree.md
@@ -1,0 +1,6 @@
+---
+"@rpch/rpc-server": minor
+---
+
+- changed default port to 45750
+- added cors headers to allow using it locally, can be disabled with `RESTRICT_CORS`

--- a/.changeset/metal-trees-guess.md
+++ b/.changeset/metal-trees-guess.md
@@ -1,0 +1,5 @@
+---
+"@rpch/discovery-platform": patch
+---
+
+fixed error text'

--- a/.changeset/six-monkeys-invent.md
+++ b/.changeset/six-monkeys-invent.md
@@ -1,0 +1,7 @@
+---
+"@rpch/sdk": minor
+---
+
+- be more verbose about failing Discovery Platform requests
+- handle MEV PROTECTION better by checking for correct chainId
+- allow explicit MEV PROTECTION disable in SDK

--- a/apps/discovery-platform/src/index.ts
+++ b/apps/discovery-platform/src/index.ts
@@ -136,7 +136,7 @@ const main = () => {
   }
   // admin secret
   if (!process.env.ADMIN_SECRET) {
-    throw new Error("Missing 'SECRET' env var.");
+    throw new Error("Missing 'ADMIN_SECRET' env var.");
   }
   // cookie secret
   if (!process.env.SESSION_SECRET) {

--- a/apps/rpc-server/package.json
+++ b/apps/rpc-server/package.json
@@ -23,8 +23,9 @@
     "supertest": "^6.3.3"
   },
   "dependencies": {
-    "@rpch/sdk": "0.6.2",
     "@rpch/crypto-for-nodejs": "0.3.4",
+    "@rpch/sdk": "0.6.2",
+    "cors": "^2.8.5",
     "leveldown": "^6.1.1",
     "levelup": "^5.1.1"
   }

--- a/apps/rpc-server/package.json
+++ b/apps/rpc-server/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@rpch/crypto-for-nodejs": "0.3.4",
     "@rpch/sdk": "0.6.2",
-    "cors": "^2.8.5",
     "leveldown": "^6.1.1",
     "levelup": "^5.1.1"
   }

--- a/apps/rpc-server/src/index.ts
+++ b/apps/rpc-server/src/index.ts
@@ -197,6 +197,9 @@ if (require.main === module) {
       ? parseInt(process.env.RESPONSE_TIMEOUT, 10)
       : undefined,
     provider: process.env.PROVIDER,
+    disableMevProtection: new Boolean(
+      process.env.DISABLE_MEV_PROTECTION
+    ).valueOf(),
     mevProtectionProvider: process.env.MEV_PROTECTION_PROVIDER,
   };
 

--- a/apps/rpc-server/src/index.ts
+++ b/apps/rpc-server/src/index.ts
@@ -82,7 +82,7 @@ function parseBody(
 function sendRequest(
   sdk: RPChSDK,
   req: RPCrequest,
-  params: RPChRequestOps,
+  params: RequestOps,
   res: http.ServerResponse
 ) {
   sdk
@@ -209,7 +209,7 @@ if (require.main === module) {
     mevProtectionProvider: process.env.MEV_PROTECTION_PROVIDER,
   };
 
-  const serverOps = { restrictCors: process.env.RESTRICT_CORS };
+  const serverOps = { restrictCors: !!process.env.RESTRICT_CORS };
   const port = determinePort(process.env.PORT);
 
   const sdk = new RPChSDK(clientId, RPChCrypto, ops);

--- a/apps/rpc-server/src/index.ts
+++ b/apps/rpc-server/src/index.ts
@@ -11,6 +11,7 @@ const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "OPTIONS, POST, GET",
   "Access-Control-Max-Age": 2592000,
+  "Access-Control-Allow-Headers": "*",
 };
 
 const defaultPort = 45750;
@@ -111,7 +112,7 @@ function createServer(sdk: RPChSDK, ops: ServerOPS) {
       log.error("Unexpected error occured on http.Response", err);
     });
 
-    if (!!ops.restrictCors) {
+    if (!ops.restrictCors) {
       // handle preflight cors
       if (req.method === "OPTIONS") {
         res.writeHead(204, corsHeaders);

--- a/apps/rpc-server/src/index.ts
+++ b/apps/rpc-server/src/index.ts
@@ -1,11 +1,5 @@
 import http from "http";
-import RPChSDK, {
-  RPCrequest,
-  RPCresult,
-  RPCerror,
-  type RequestOps,
-  type Ops as SDKops,
-} from "@rpch/sdk";
+import RPChSDK, { JRPC, type RequestOps, type Ops as SDKops } from "@rpch/sdk";
 import * as RPChCrypto from "@rpch/crypto-for-nodejs";
 import { utils } from "@rpch/common";
 
@@ -52,7 +46,7 @@ function parseBody(
   str: string
 ):
   | { success: false; error: string; id?: string }
-  | { success: true; req: RPCrequest } {
+  | { success: true; req: JRPC.Request } {
   try {
     const json = JSON.parse(str);
     if (!("jsonrpc" in json)) {
@@ -77,13 +71,13 @@ function parseBody(
 
 function sendRequest(
   sdk: RPChSDK,
-  req: RPCrequest,
+  req: JRPC.Request,
   params: RequestOps,
   res: http.ServerResponse
 ) {
   sdk
     .send(req, params)
-    .then((resp: RPCresult | RPCerror) => {
+    .then((resp: JRPC.Response) => {
       log.verbose("receiving response", JSON.stringify(resp));
       res.statusCode = 200;
       res.write(JSON.stringify(resp));

--- a/apps/rpc-server/src/index.ts
+++ b/apps/rpc-server/src/index.ts
@@ -40,16 +40,12 @@ function extractParams(
   if (!url) {
     return {};
   }
-  const exitProvider = url.searchParams.get("exit-provider");
+  const provider = url.searchParams.get("provider");
   const timeout = url.searchParams.get("timeout");
-  const params: Record<string, string | number> = {};
-  if (exitProvider != null) {
-    params.exitProvider = exitProvider;
-  }
-  if (timeout != null) {
-    params.timeout = parseInt(timeout, 10);
-  }
-  return params;
+  return {
+    provider: provider ? provider : undefined,
+    timeout: timeout ? parseInt(timeout, 10) : undefined,
+  };
 }
 
 function parseBody(

--- a/packages/sdk/src/dp-api.ts
+++ b/packages/sdk/src/dp-api.ts
@@ -78,7 +78,13 @@ export function fetchNodes(
 
   return retry(async (bail, num) => {
     if (num > 1) {
-      log.verbose("Retrying", url.toString(), "after", num - 1, "failure(s)");
+      log.verbose(
+        "Retrying",
+        url.host.toString(),
+        "after",
+        num - 1,
+        "failure(s)"
+      );
     }
     const res = await fetch(url, { headers });
     if (res.status !== 200) {

--- a/packages/sdk/src/dp-api.ts
+++ b/packages/sdk/src/dp-api.ts
@@ -59,7 +59,7 @@ export function fetchNode(ops: Ops, peerId: string): Promise<RawNode> {
 
   return retry(async (_bail) => {
     const res = await fetch(url, { headers });
-    return res.json();
+    return res.json() as unknown as RawNode;
   }, DefaultBackoff);
 }
 
@@ -95,8 +95,8 @@ export function fetchNodes(
         return bail(new Error(NoMoreNodes));
       case 400: // validation errors
       case 403: // unauthorized
-        return bail(new Error(await res.json()));
+        return bail(new Error((await res.json()) as unknown as string));
     }
-    return res.json();
-  }, DefaultBackoff);
+    return res.json() as unknown as Nodes;
+  }, DefaultBackoff) as Promise<Nodes>;
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,7 +11,8 @@ import * as RequestCache from "./request-cache";
 import * as Response from "./response";
 import * as Segment from "./segment";
 import * as SegmentCache from "./segment-cache";
-import * as Jrpc from "./jrpc";
+import * as JRPC from "./jrpc";
+export * as JRPC from "./jrpc";
 
 /**
  * HOPR SDK options provide global defaults.
@@ -124,9 +125,9 @@ export default class SDK {
    * See **RequestOps** for overridable options.
    */
   public async send(
-    req: Jrpc.Request,
+    req: JRPC.Request,
     ops?: RequestOps
-  ): Promise<Jrpc.Response> {
+  ): Promise<JRPC.Response> {
     const reqOps = this.requestOps(ops);
     this.populateChainIds(ops?.provider);
     return new Promise(async (resolve, reject) => {
@@ -470,7 +471,7 @@ export default class SDK {
     if (!res) {
       return;
     }
-    if (Jrpc.isError(res)) {
+    if (JRPC.isError(res)) {
       log.info(
         "Unable to resolve chainId for",
         provider,
@@ -484,7 +485,7 @@ export default class SDK {
 
   private determineProvider = (
     { provider }: { provider: string },
-    { method }: Jrpc.Request
+    { method }: JRPC.Request
   ): string => {
     if (this.ops.disableMevProtection) {
       return provider;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -106,9 +106,7 @@ export default class SDK {
     private readonly crypto: typeof RPChCrypto,
     ops: Ops = {}
   ) {
-    console.log("construct ops", ops);
     this.ops = this.sdkOps(ops);
-    console.log("after construct ops", this.ops);
     this.crypto = crypto;
     this.crypto.set_panic_hook();
     this.requestCache = RequestCache.init();
@@ -149,10 +147,7 @@ export default class SDK {
     req: RPCrequest,
     ops?: RequestOps
   ): Promise<RPCresult | RPCerror> {
-    console.log("this.ops", this.ops);
-    console.log("ops", ops);
     const reqOps = this.requestOps(ops);
-    console.log("reqops", reqOps);
     return new Promise(async (resolve, reject) => {
       // sanity check provider url
       if (!utils.isValidURL(reqOps.provider!)) {

--- a/packages/sdk/src/jrpc.ts
+++ b/packages/sdk/src/jrpc.ts
@@ -1,0 +1,37 @@
+export type Request = {
+  readonly jsonrpc: "2.0";
+  id?: string | number | null;
+  method: string;
+  params?: any[] | object;
+};
+
+export type Response = Result | Error;
+
+export type Result = {
+  readonly jsonrpc: "2.0";
+  id?: string | number | null;
+  result: any;
+};
+
+export type Error = {
+  readonly jsonrpc: "2.0";
+  id?: string | number | null;
+  error: {
+    code: number;
+    message: string;
+    data?: any;
+  };
+};
+
+export function chainId(id: string) {
+  return {
+    jsonrpc: "2.0",
+    method: "eth_chainId",
+    id,
+    params: [],
+  };
+}
+
+export function isError(r: Response): r is Error {
+  return "error" in r;
+}

--- a/packages/sdk/src/node-api.ts
+++ b/packages/sdk/src/node-api.ts
@@ -35,8 +35,8 @@ export function sendMessage(
     peerId: recipient,
     tag,
   });
-  return fetch(url, { method: "POST", headers, body }).then((res) =>
-    res.json()
+  return fetch(url, { method: "POST", headers, body }).then(
+    (res) => res.json() as unknown as string
   );
 }
 
@@ -62,6 +62,6 @@ export function retrieveMessages(
   };
   const body = JSON.stringify({ tag });
   return fetch(url, { method: "POST", headers, body }).then((res) => {
-    return res.json();
+    return res.json() as unknown as { messages: Message[] };
   });
 }

--- a/packages/sdk/src/provider-api.ts
+++ b/packages/sdk/src/provider-api.ts
@@ -1,10 +1,10 @@
-import * as Jrpc from "./jrpc";
+import * as JRPC from "./jrpc";
 
-export function fetchChainId(provider: string): Promise<Jrpc.Response> {
+export function fetchChainId(provider: string): Promise<JRPC.Response> {
   const url = new URL(provider);
   const headers = { "Content-Type": "application/json" };
-  const body = JSON.stringify(Jrpc.chainId(provider));
+  const body = JSON.stringify(JRPC.chainId(provider));
   return fetch(url, { headers, method: "POST", body }).then(
-    (r) => r.json() as unknown as Jrpc.Response
+    (r) => r.json() as unknown as JRPC.Response
   );
 }

--- a/packages/sdk/src/provider-api.ts
+++ b/packages/sdk/src/provider-api.ts
@@ -1,0 +1,10 @@
+import * as Jrpc from "./jrpc";
+
+export function fetchChainId(provider: string): Promise<Jrpc.Response> {
+  const url = new URL(provider);
+  const headers = { "Content-Type": "application/json" };
+  const body = JSON.stringify(Jrpc.chainId(provider));
+  return fetch(url, { headers, method: "POST", body }).then(
+    (r) => r.json() as unknown as Jrpc.Response
+  );
+}

--- a/packages/sdk/src/request-cache.ts
+++ b/packages/sdk/src/request-cache.ts
@@ -1,10 +1,10 @@
 import type { Request } from "./request";
-import * as Jrpc from "./jrpc";
+import * as JRPC from "./jrpc";
 
 export type Cache = Map<number, Entry>; // id -> Request
 
 export type Entry = Request & {
-  resolve: (res: Jrpc.Response) => void;
+  resolve: (res: JRPC.Response) => void;
   reject: (error: string) => void;
   timer: ReturnType<typeof setTimeout>;
 };
@@ -19,7 +19,7 @@ export function init(): Cache {
 export function add(
   cache: Cache,
   request: Request,
-  resolve: (res: Jrpc.Response) => void,
+  resolve: (res: JRPC.Response) => void,
   reject: (error: string) => void,
   timer: ReturnType<typeof setTimeout>
 ): Entry {

--- a/packages/sdk/src/request-cache.ts
+++ b/packages/sdk/src/request-cache.ts
@@ -1,10 +1,10 @@
 import type { Request } from "./request";
-import type { RPCresult, RPCerror } from "./index";
+import * as Jrpc from "./jrpc";
 
 export type Cache = Map<number, Entry>; // id -> Request
 
 export type Entry = Request & {
-  resolve: (res: RPCresult | RPCerror) => void;
+  resolve: (res: Jrpc.Response) => void;
   reject: (error: string) => void;
   timer: ReturnType<typeof setTimeout>;
 };
@@ -19,7 +19,7 @@ export function init(): Cache {
 export function add(
   cache: Cache,
   request: Request,
-  resolve: (res: RPCresult | RPCerror) => void,
+  resolve: (res: Jrpc.Response) => void,
   reject: (error: string) => void,
   timer: ReturnType<typeof setTimeout>
 ): Entry {

--- a/packages/sdk/src/request.ts
+++ b/packages/sdk/src/request.ts
@@ -6,7 +6,7 @@ import type {
   Identity,
 } from "@rpch/crypto-for-nodejs";
 
-import * as Jrpc from "./jrpc";
+import * as JRPC from "./jrpc";
 import * as compression from "./compression";
 import type { Segment } from "./segment";
 import { shortPeerId } from "./utils";
@@ -15,7 +15,7 @@ export type Request = {
   id: number;
   originalId?: number;
   provider: string;
-  req: Jrpc.Request;
+  req: JRPC.Request;
   createdAt: number;
   entryId: string; // peerID
   exitId: string; // peerID
@@ -38,7 +38,7 @@ export function create(
   },
   id: number,
   provider: string,
-  req: Jrpc.Request,
+  req: JRPC.Request,
   entryId: string,
   exitId: string,
   exitNodeReadIdentity: Identity

--- a/packages/sdk/src/request.ts
+++ b/packages/sdk/src/request.ts
@@ -6,8 +6,8 @@ import type {
   Identity,
 } from "@rpch/crypto-for-nodejs";
 
+import * as Jrpc from "./jrpc";
 import * as compression from "./compression";
-import type { RPCrequest } from ".";
 import type { Segment } from "./segment";
 import { shortPeerId } from "./utils";
 
@@ -15,7 +15,7 @@ export type Request = {
   id: number;
   originalId?: number;
   provider: string;
-  req: RPCrequest;
+  req: Jrpc.Request;
   createdAt: number;
   entryId: string; // peerID
   exitId: string; // peerID
@@ -38,7 +38,7 @@ export function create(
   },
   id: number,
   provider: string,
-  req: RPCrequest,
+  req: Jrpc.Request,
   entryId: string,
   exitId: string,
   exitNodeReadIdentity: Identity

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -17,10 +17,10 @@ export function average(arr: number[]): number {
 
 export function isValidURL(url: string) {
   if ("canParse" in URL) {
-    // @ts-ignore
     return URL.canParse(url);
   }
   try {
+    // @ts-ignore
     new URL(url);
     return true;
   } catch (_ex) {

--- a/turbo.json
+++ b/turbo.json
@@ -70,6 +70,7 @@
       "env": [
         "ADMIN_SECRET",
         "DATABASE_URL",
+        "RESTRICT_CORS",
         "GOOGLE_CLIENT_ID",
         "GOOGLE_CLIENT_SECRET",
         "PORT",

--- a/turbo.json
+++ b/turbo.json
@@ -70,7 +70,6 @@
       "env": [
         "ADMIN_SECRET",
         "DATABASE_URL",
-        "RESTRICT_CORS",
         "GOOGLE_CLIENT_ID",
         "GOOGLE_CLIENT_SECRET",
         "PORT",
@@ -91,6 +90,8 @@
         "DISCOVERY_PLATFORM_API_ENDPOINT",
         "CLIENT",
         "PROVIDER",
+        "RESTRICT_CORS",
+        "DISABLE_MEV_PROTECTION",
         "MEV_PROTECTION_PROVIDER"
       ]
     },


### PR DESCRIPTION
this enables cors headers, so that RPCh will work in Firefox.
MEV protection now has some sanity checks to see if it really triggers