### PR TITLE
Migration of RPCh Crypto to TS

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -10,5 +10,11 @@
     "format": "prettier --write src/",
     "lint": "eslint --fix src/",
     "test": "jest --coverage"
+  },
+  "dependencies": {
+    "secp256k1": "5.0.0",
+    "futoin-hkdf": "1.5.3",
+    "blake2": "5.0.0",
+    "chacha": "2.1.0"
   }
 }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpch/crypto",
-  "version": "0.0.0",
+  "version": "0.4.0",
   "license": "LGPL-3.0",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -15,6 +15,6 @@
     "secp256k1": "5.0.0",
     "futoin-hkdf": "1.5.3",
     "blake2": "5.0.0",
-    "chacha": "2.1.0"
+    "@noble/ciphers": "0.3.0"
   }
 }

--- a/packages/crypto/src/index.spec.ts
+++ b/packages/crypto/src/index.spec.ts
@@ -1,0 +1,133 @@
+import {box_request, box_response, Envelope, Identity, Session, unbox_request, unbox_response} from "./index";
+import assert from "assert";
+
+const EXIT_NODE_PK = '03d73c98d44618b7504bab1001adaa0a0c77adfb04db4b7732b1daba5e6523e7bf'
+const EXIT_NODE_SK = '06ef2a621eb9df81f7d6a8f7a2499b9e670613f757648dc3258640767ebd7e0a'
+const EXIT_NODE = '16Uiu2HAmUsJwbECMroQUC29LQZZWsYpYZx1oaM1H9DBoZHLkYn12'
+const ENTRY_NODE = '16Uiu2HAm35DuQk2Cvp9aLpRTD43ZubLqtbAwf242w2YmAe8FskLs'
+
+const TEST_VECTOR_EPHEMERAL_PRIVATE_KEY = '492057cf93e99b31d2a85bc5e98a9c3aa0021feec52c227cc8170e8f7d047775'
+const TEST_VECTOR_EPHEMERAL_SECRET = 'a27198fe268cd0af95a8c39788d44fc26638971e77ded9ee965b37e5d5d4a553'
+
+const TEST_VECTOR_REQUEST_INPUT = 'e1afa1e0a0a3e482bce0be80e39ca4e5a0a4e681b3d1a0e19ca8c390d7bbe380b9e69aa0e7a982ceb8cf92e4bebce7b0a5e589abe184b4c7b0e28ca0e38786e69f92e2a7a8c288e287b8c3b9e68587e19ba0e0a580e4baa439e4a8b44363d0a5e6968ac9a0e28580d297e294a8e4ad83e3ada0e2b6b2e399ace2a192e1a58ee380a7e6a58ee0aaaee680bae680aee280b5e69a89e29596e5a0bae495ace6beaee480a6e6a0a2e794a476e7b188e3a4bbe1b6b6e280a4e69a8050e480a1e3bab9e280a020'
+const TEST_VECTOR_REQUEST_OUTPUT = '120239d1bc2291826eaed86567d225cf243ebc637275e0a5aedb0d6b1dc82136a38e000001856a69d98192302d2c0a27a012e61e086fcac4977d61805617aace48a42cc6d37d4cf7276a39c0cc81de4da122d1ead7c0ae047ae727ca788c17137455caf712265e84edeca71e5cf80119d30e09e55a9d4546178cbc254004ffa780166f154516939033e8476bf6aa332706f604289c3e22fb5a9f93dc312b9d0981c44cc48344e4f8db3e6b2a9b3d0365d5b4a96e51eae57709db62f72ce4768e88f054f8634655e6938d05e02179e308b579f352ef039e5e3f56925c03f05058b305f6f792a7e6a31ac3faace94fa667ea5254bc6937d6c7f2cc3cb4f134'
+const TEST_VECTOR_RESPONSE_INPUT = 'e1afa1e0a0b3e485ace0b480dcb0e19d88cb92e48496c7b9e48ca3e0b0b2c2b8c7b0c2812dd0a1e198a0e4b490da8ae59693e68da0e197a0e0b6a0e19d9de490a1e780b1e4b5b8e48193e1bca0e18790e4a0a0e5bd89e280a020'
+const TEST_VECTOR_RESPONSE_OUTPUT = '000001856a69d9816d0a1e6ed9cfe3b95125d3ae02400ea86d869fce21b7e6241d22dbe911182c51345c8eb13ebc9c5cf9989e7e0f9cac2cd2a3026cc06d6fca6f2df1b45ee17f94543194b0f7f285cf261348b729fd78d6bb9a2021ca947b49f3ccbc36d43eea6efef2c4e25c205bb1286d'
+const TEST_COUNTER = 1672527600000
+
+function fromHex(str: string) {
+    return Uint8Array.from(Buffer.from(str, 'hex'))
+}
+
+function toHex(bytes: Uint8Array | undefined) {
+    if (!bytes) return ''
+    return Buffer.from(bytes).toString('hex')
+}
+
+describe('RPCh Crypto protocol tests', function () {
+    it('test vectors on fixed request input', async function () {
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date(TEST_COUNTER))
+
+        // Client side
+
+        let request_data: Envelope = {
+            message: fromHex(TEST_VECTOR_REQUEST_INPUT),
+            entryPeerId: ENTRY_NODE,
+            exitPeerId: EXIT_NODE
+        }
+
+        let exit_id: Identity = {
+            publicKey: fromHex(EXIT_NODE_PK)
+        }
+
+        let req_box_result = box_request(request_data, exit_id, (_) => fromHex(TEST_VECTOR_EPHEMERAL_PRIVATE_KEY))
+        assert(!req_box_result.isErr, `request boxing must not fail, error: ${req_box_result.message}`)
+
+        let client_request_session = req_box_result.session
+        assert(client_request_session != undefined, 'must contain a valid session')
+
+        assert(client_request_session.request != undefined, 'session must contain request data')
+        assert.equal(toHex(client_request_session.request), TEST_VECTOR_REQUEST_OUTPUT, 'session data must be equal to test vector')
+        assert.equal(client_request_session.updatedTS, TEST_COUNTER + 1, 'TS must be increased')
+
+        // Client side end
+
+        let data_on_wire = client_request_session.request
+
+        // Exit node side
+
+        jest.setSystemTime(new Date(TEST_COUNTER + 10))
+
+        let received_req_data: Envelope = {
+            message: data_on_wire,
+            entryPeerId: ENTRY_NODE,
+            exitPeerId: EXIT_NODE
+        }
+
+        let exit_node_identity: Identity = {
+            publicKey: fromHex(EXIT_NODE_PK),
+            privateKey: fromHex(EXIT_NODE_SK)
+        }
+
+        let req_unbox_result = unbox_request(received_req_data, exit_node_identity, new Date(TEST_COUNTER))
+        assert(!req_unbox_result.isErr, `request unboxing must not fail, error: ${req_unbox_result.message}`)
+
+        let exit_request_session = req_unbox_result.session
+        assert(exit_request_session != undefined, 'must contain a valid session')
+
+        assert.equal(toHex(exit_request_session.request), TEST_VECTOR_REQUEST_INPUT)
+        assert.equal(exit_request_session.updatedTS, TEST_COUNTER + 1)
+    });
+
+    it('test vectors on fixed response input', async function () {
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date(TEST_COUNTER))
+
+        // Exit node side
+
+        let mock_session_with_client: Session = {
+            updatedTS: BigInt(1),
+            sharedPreSecret: fromHex(TEST_VECTOR_EPHEMERAL_SECRET)
+        }
+
+        let response_data: Envelope = {
+            message: fromHex(TEST_VECTOR_RESPONSE_INPUT),
+            entryPeerId: ENTRY_NODE,
+            exitPeerId: EXIT_NODE
+        }
+
+        let resp_box_result = box_response(mock_session_with_client, response_data)
+        assert(!resp_box_result.isErr, `response boxing must not fail, error: ${resp_box_result.message}`)
+
+        assert(mock_session_with_client.response != undefined)
+        assert.equal(toHex(mock_session_with_client.response), TEST_VECTOR_RESPONSE_OUTPUT)
+        assert.equal(mock_session_with_client.updatedTS, TEST_COUNTER + 1)
+
+        // Exit node side end
+
+        let data_on_wire = mock_session_with_client.response
+
+        // Client node side
+
+        jest.setSystemTime(new Date(TEST_COUNTER + 10))
+
+        let received_req_data: Envelope = {
+            message: data_on_wire,
+            entryPeerId: ENTRY_NODE,
+            exitPeerId: EXIT_NODE
+        }
+
+        let mock_session_with_exit_node: Session = {
+            updatedTS: BigInt(1),
+            sharedPreSecret: fromHex(TEST_VECTOR_EPHEMERAL_SECRET)
+        }
+
+        let resp_unbox_result = unbox_response(mock_session_with_exit_node, received_req_data, new Date(TEST_COUNTER))
+        assert(!resp_unbox_result.isErr, `response unboxing must not fail, error: ${resp_unbox_result.message}`)
+
+        assert(mock_session_with_exit_node.response != undefined)
+        assert.equal(toHex(mock_session_with_exit_node.response), TEST_VECTOR_RESPONSE_INPUT)
+        assert.equal(mock_session_with_exit_node.updatedTS, TEST_COUNTER + 1)
+    });
+});

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,5 +1,70 @@
-const world = 'world';
+import { hash_length, extract, expand } from 'futoin-hkdf'
+import { chacha20poly1305 } from '@noble/ciphers/chacha'
 
-export function hello(who: string = world): string {
-  return `Hello ${who}! `;
+
+export type Envelope = {
+  message: Uint8Array,
+  entryPeerId: string,
+  exitPeerId: string,
+}
+
+export class Identity {
+  constructor(private publicKey: Uint8Array, private privateKey?: Uint8Array) {}
+}
+
+export type Session = {
+  request: Uint8Array,
+  response: Uint8Array,
+  updatedTS: Date
+}
+
+export class Result<T> {
+  constructor(public readonly ok: T | undefined, public readonly error: string, public readonly is_err: boolean) {
+  }
+  public static ok<T>(res: T) {
+    return new Result<T>(res, "", false)
+  }
+  public static err<T>(err: string) {
+    return new Result<T>(undefined, err, true)
+  }
+}
+
+const TIMESTAMP_TOLERANCE_MS = 30_000; // milliseconds
+const CIPHER_KEY_LEN = 32;
+const CIPHER_IV_LEN = 12;
+const COUNTER_LEN = 4;
+const BLAKE2S256_HASH = 'blake2s256'
+
+function initializeCipher(shared_presecret: Uint8Array, counter: number, salt: Uint8Array, startIndex: number) {
+  const hashLen = hash_length(BLAKE2S256_HASH);
+  const prk = extract(BLAKE2S256_HASH, hashLen, Buffer.from(shared_presecret), Buffer.from(salt))
+
+  const cipherKeyLen = CIPHER_KEY_LEN;
+  const cipherIvLen = CIPHER_IV_LEN - COUNTER_LEN;
+  const idx = new Uint8Array(1);
+
+  idx[0] = startIndex;
+  const key = expand(BLAKE2S256_HASH, hashLen, prk, cipherKeyLen, Buffer.from(idx))
+  idx[0] = startIndex + 1;
+  const ivm = expand(BLAKE2S256_HASH, hashLen, prk, cipherIvLen, Buffer.from(idx))
+  ivm.writeUint32BE(counter, cipherIvLen)
+
+  return chacha20poly1305(key, ivm)
+}
+
+export function box_request(request: Envelope, exitNode: Identity): Result<Session> {
+
+  return Result.err("not implemented")
+}
+
+export function unbox_request(request: Envelope, myId: Identity, lastTsOfThisClient: Date): Result<Session> {
+  return Result.err("not implemented")
+}
+
+export function box_response(session: Session, response: Envelope): Result<void> {
+  return Result.err("not implemented")
+}
+
+export function unbox_response(session: Session, response: Envelope, lastTsOfThisExitNode: Date): Result<void> {
+  return Result.err("not implemented")
 }

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -109,10 +109,8 @@ function generateEphemeralKey(randomFn: (len: number) => Uint8Array) {
 }
 
 /// Extracts the X coordinate from the ECDH result
-function getXCoord(x: any, _y: any) {
-  const pubKey = new Uint8Array(32)
-  pubKey.set(x)
-  return pubKey
+function getXCoord(x: any, _: any) {
+  return new Uint8Array(x)
 }
 
 /// Validates that (lowerBound - tolerance) <= value <= (upperBound + tolerance)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,6 +1342,11 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz#648f79c4e09279212ac90d871646ae12d80cdfce"
   integrity sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==
 
+"@noble/ciphers@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-0.3.0.tgz#6ba3090afdc7a7051393486f6af210e62e0f04ec"
+  integrity sha512-ldbrnOjmNRwFdXcTM6uXDcxpMIFrbzAWNnpBPp4oTJTFF0XByGD6vf45WrehZGXRQTRVV+Zm8YP+EgEf+e4cWA==
+
 "@noble/ed25519@^1.5.1":
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.3.tgz#57e1677bf6885354b466c38e2b620c62f45a7123"
@@ -2801,6 +2806,13 @@ bintrees@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
   integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
+
+blake2@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/blake2/-/blake2-5.0.0.tgz#6306e49d974fb051b6fb2aad669307b9838bfbaa"
+  integrity sha512-MLpq1DwBB9rC0IHuRc2gXLEAeNNTTYHEtvYCA5lK4RmoUPRmQLSLQrwgJvou62BvH9KP7whe8n+xxw45++fnYg==
+  dependencies:
+    nan "^2.17.0"
 
 blakejs@^1.1.0:
   version "1.2.1"
@@ -4680,6 +4692,11 @@ functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+futoin-hkdf@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz#6c8024f2e1429da086d4e18289ef2239ad33ee35"
+  integrity sha512-SewY5KdMpaoCeh7jachEWFsh1nNlaDjNHZXWqL5IGwtpEYHTgkr2+AMCgNwKWkcc0wpSYrZfR7he4WdmHFtDxQ==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -6580,6 +6597,11 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
+nan@^2.17.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
+  integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
+
 nanoid@3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
@@ -6643,6 +6665,11 @@ node-addon-api@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
+
+node-addon-api@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
+  integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
 
 node-fetch@^2.6.12:
   version "2.7.0"
@@ -7673,6 +7700,15 @@ scrypt-js@3.0.1, scrypt-js@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
   integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
+
+secp256k1@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-5.0.0.tgz#be6f0c8c7722e2481e9773336d351de8cddd12f7"
+  integrity sha512-TKWX8xvoGHrxVdqbYeZM9w+izTF4b9z3NhSaDkdn81btvuh+ivbIMGT/zQvDtTFWhRlThpoz6LEYTr7n8A5GcA==
+  dependencies:
+    elliptic "^6.5.4"
+    node-addon-api "^5.0.0"
+    node-gyp-build "^4.2.0"
 
 secp256k1@^4.0.1:
   version "4.0.3"


### PR DESCRIPTION
This PR migrates the RPCh Crypto protocol version `0x12` to TS.

The TS implementation is fully compatible with the Rust implementation in https://github.com/Rpc-h/crypto at the same version.

Closes #425