### PR TITLE
Add optional UUID to the box/unbox functions

### DIFF
--- a/packages/compat-crypto/src/index.spec.ts
+++ b/packages/compat-crypto/src/index.spec.ts
@@ -1,6 +1,7 @@
 import assert = require('assert');
 import { isError, boxRequest, boxResponse, Session, unboxRequest, unboxResponse } from './index';
 import { randomBytes } from 'crypto';
+import * as crypto from 'crypto';
 
 const EXIT_NODE_PK = '03d73c98d44618b7504bab1001adaa0a0c77adfb04db4b7732b1daba5e6523e7bf';
 const EXIT_NODE_SK = '06ef2a621eb9df81f7d6a8f7a2499b9e670613f757648dc3258640767ebd7e0a';
@@ -35,9 +36,11 @@ describe('RPCh Crypto protocol tests', function () {
     it('test request flow', async function () {
         // Client side
         const request_msg = new Uint8Array(randomBytes(300));
+        const request_uuid = crypto.randomUUID();
 
         const request_data = {
             message: request_msg,
+            uuid: request_uuid,
             exitPeerId: EXIT_NODE,
             exitPublicKey: fromHex(EXIT_NODE_PK),
         };
@@ -58,11 +61,13 @@ describe('RPCh Crypto protocol tests', function () {
 
         const client_req_creation_ts = client_request_session.updatedTS;
         const data_on_wire = client_request_session.request;
+        // also request_uuid gets sent next to the data
 
         // Exit node side
 
         const received_req_data = {
             message: data_on_wire,
+            uuid: request_uuid,
             exitPeerId: EXIT_NODE,
             exitPrivateKey: fromHex(EXIT_NODE_SK),
         };
@@ -85,6 +90,7 @@ describe('RPCh Crypto protocol tests', function () {
     it('test response flow', async function () {
         // Exit node side
         const response_msg = new Uint8Array(randomBytes(300));
+        const response_uuid = crypto.randomUUID();
 
         const mock_session_with_client: Session = {
             updatedTS: BigInt(1),
@@ -93,6 +99,7 @@ describe('RPCh Crypto protocol tests', function () {
 
         const response_data = {
             message: response_msg,
+            uuid: response_uuid,
             entryPeerId: ENTRY_NODE,
         };
 
@@ -109,11 +116,13 @@ describe('RPCh Crypto protocol tests', function () {
 
         const exit_node_resp_creation_ts = mock_session_with_client.updatedTS;
         const data_on_wire = mock_session_with_client.response;
+        // also request_uuid gets sent next to the data
 
         // Client node side
 
         const received_resp_data = {
             message: data_on_wire,
+            uuid: response_uuid,
             entryPeerId: ENTRY_NODE,
         };
 
@@ -138,9 +147,11 @@ describe('RPCh Crypto protocol tests', function () {
     it('test complete flow', async function () {
         // Client side
         const request_msg = new Uint8Array(randomBytes(300));
+        const request_uuid = crypto.randomUUID();
 
         const request_data = {
             message: request_msg,
+            uuid: request_uuid,
             exitPeerId: EXIT_NODE,
             exitPublicKey: fromHex(EXIT_NODE_PK),
         };
@@ -161,12 +172,14 @@ describe('RPCh Crypto protocol tests', function () {
 
         const client_req_creation_ts = client_session.updatedTS;
         const request_data_on_wire = client_session.request;
+        // also request_uuid gets sent next to the data
 
         // Exit node side
 
         const received_req_data = {
             message: request_data_on_wire,
             exitPeerId: EXIT_NODE,
+            uuid: request_uuid,
             exitPrivateKey: fromHex(EXIT_NODE_SK),
         };
 
@@ -186,9 +199,11 @@ describe('RPCh Crypto protocol tests', function () {
 
         // Exit node side
         const response_msg = new Uint8Array(randomBytes(300));
+        const response_uuid = crypto.randomUUID();
 
         const response_data = {
             message: response_msg,
+            uuid: response_uuid,
             entryPeerId: ENTRY_NODE,
         };
 
@@ -205,11 +220,13 @@ describe('RPCh Crypto protocol tests', function () {
 
         const exit_node_resp_creation_ts = exit_session.updatedTS;
         const response_data_on_wire = exit_session.response;
+        // also response_uuid gets sent next to the data
 
         // Client node side
 
         const received_resp_data = {
             message: response_data_on_wire,
+            uuid: response_uuid,
             entryPeerId: ENTRY_NODE,
         };
 

--- a/packages/compat-crypto/src/index.spec.ts
+++ b/packages/compat-crypto/src/index.spec.ts
@@ -1,6 +1,5 @@
 import assert = require('assert');
 import { isError, boxRequest, boxResponse, Session, unboxRequest, unboxResponse } from './index';
-import { randomBytes } from 'crypto';
 import * as crypto from 'crypto';
 
 const EXIT_NODE_PK = '03d73c98d44618b7504bab1001adaa0a0c77adfb04db4b7732b1daba5e6523e7bf';
@@ -35,7 +34,7 @@ function toHex(bytes: Uint8Array | undefined) {
 describe('RPCh Crypto protocol tests', function () {
     it('test request flow', async function () {
         // Client side
-        const request_msg = new Uint8Array(randomBytes(300));
+        const request_msg = new Uint8Array(crypto.randomBytes(300));
         const request_uuid = crypto.randomUUID();
 
         const request_data = {
@@ -89,7 +88,7 @@ describe('RPCh Crypto protocol tests', function () {
 
     it('test response flow', async function () {
         // Exit node side
-        const response_msg = new Uint8Array(randomBytes(300));
+        const response_msg = new Uint8Array(crypto.randomBytes(300));
         const response_uuid = crypto.randomUUID();
 
         const mock_session_with_client: Session = {
@@ -146,7 +145,7 @@ describe('RPCh Crypto protocol tests', function () {
 
     it('test complete flow', async function () {
         // Client side
-        const request_msg = new Uint8Array(randomBytes(300));
+        const request_msg = new Uint8Array(crypto.randomBytes(300));
         const request_uuid = crypto.randomUUID();
 
         const request_data = {
@@ -198,7 +197,7 @@ describe('RPCh Crypto protocol tests', function () {
         assert.equal(exit_session.updatedTS, client_req_creation_ts);
 
         // Exit node side
-        const response_msg = new Uint8Array(randomBytes(300));
+        const response_msg = new Uint8Array(crypto.randomBytes(300));
         const response_uuid = crypto.randomUUID();
 
         const response_data = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6316,11 +6316,6 @@ utils-merge@1.0.1, utils-merge@^1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
-
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6316,6 +6316,11 @@ utils-merge@1.0.1, utils-merge@^1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"


### PR DESCRIPTION
This PR adds optional UUID as Additional Authenticated Data (AAD) to the request and responses.

Note that UUID when boxing must match the UUID when unboxing, otherwise the operation will fail.

If UUID is omitted, the protocol will behave as backwards compatible.

Closes #571