### PR TITLE
Este/dbglvl

### DIFF
--- a/.changeset/old-guests-smile.md
+++ b/.changeset/old-guests-smile.md
@@ -1,0 +1,8 @@
+---
+'@rpch/rpc-server': patch
+'@rpch/sdk': patch
+---
+
+Expose `DEBUG_LEVEL` in RPC server and allow debugLevel ops parameter in SDK.
+This will set a minimal debug level and can be used in addition with scope to better control logging output.
+SDK and RPC-Server now default to `info` log level.

--- a/.changeset/old-guests-smile.md
+++ b/.changeset/old-guests-smile.md
@@ -6,3 +6,4 @@
 Expose `DEBUG_LEVEL` in RPC server and allow debugLevel ops parameter in SDK.
 This will set a minimal debug level and can be used in addition with scope to better control logging output.
 SDK and RPC-Server now default to `info` log level.
+Will only use default log level if `DEBUG` is not set.

--- a/apps/rpc-server/src/index.ts
+++ b/apps/rpc-server/src/index.ts
@@ -326,6 +326,7 @@ if (require.main === module) {
         segmentLimit: process.env.SEGMENT_LIMIT
             ? parseInt(process.env.SEGMENT_LIMIT, 10)
             : undefined,
+        debugLevel: process.env.DEBUG_LEVEL,
         versionListener,
     };
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -61,7 +61,7 @@ export type Ops = {
     readonly segmentLimit?: number;
     readonly versionListener?: (versions: DPapi.Versions) => void;
     readonly debugScope?: string;
-    readonly debugLevel?: 'verbose' | 'info' | 'warn' | 'error';
+    readonly debugLevel?: string; // 'verbose' | 'info' | 'warn' | 'error'
     readonly forceManualRelaying?: boolean;
 };
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -89,6 +89,7 @@ const defaultOps: Ops = {
     forceZeroHop: false,
     segmentLimit: 0, // disable segment limit
     forceManualRelaying: false,
+    debugLevel: 'info',
 };
 
 const log = Utils.logger(['sdk']);
@@ -533,7 +534,7 @@ export default class SDK {
             segmentLimit: ops.segmentLimit ?? defaultOps.segmentLimit,
             versionListener: ops.versionListener,
             debugScope: ops.debugScope,
-            debugLevel: ops.debugLevel,
+            debugLevel: ops.debugLevel || (process.env.DEBUG ? undefined : defaultOps.debugLevel),
             forceManualRelaying: ops.forceManualRelaying ?? defaultOps.forceManualRelaying,
         };
     };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -48,6 +48,7 @@ export * as Utils from './utils';
  * @param segmentLimit - limit the number of segment a request can use, fails requests that require a larger number
  * @param versionListener - if you need to know what the current versions of RPCh related components are
  * @param debugScope - programatically set debug scope for SDK
+ * @param debugLevel - only print debug statements that match at least the desired level: verbose < info < warn < error
  */
 export type Ops = {
     readonly discoveryPlatformEndpoint?: string;
@@ -60,6 +61,7 @@ export type Ops = {
     readonly segmentLimit?: number;
     readonly versionListener?: (versions: DPapi.Versions) => void;
     readonly debugScope?: string;
+    readonly debugLevel?: 'verbose' | 'info' | 'warn' | 'error';
     readonly forceManualRelaying?: boolean;
 };
 
@@ -118,7 +120,8 @@ export default class SDK {
         ops: Ops = {},
     ) {
         this.ops = this.sdkOps(ops);
-        this.ops.debugScope && Utils.setDebugScope(this.ops.debugScope);
+        (this.ops.debugScope || this.ops.debugLevel) &&
+            Utils.setDebugScopeLevel(this.ops.debugScope, this.ops.debugLevel);
         this.requestCache = RequestCache.init();
         this.segmentCache = SegmentCache.init();
         this.hops = this.determineHops(!!this.ops.forceZeroHop);
@@ -530,6 +533,7 @@ export default class SDK {
             segmentLimit: ops.segmentLimit ?? defaultOps.segmentLimit,
             versionListener: ops.versionListener,
             debugScope: ops.debugScope,
+            debugLevel: ops.debugLevel,
             forceManualRelaying: ops.forceManualRelaying ?? defaultOps.forceManualRelaying,
         };
     };

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -8,6 +8,8 @@ export enum VrsnCmp {
     MajorMismatch,
 }
 
+const DefaultLogLevel = 'info';
+
 export function shortPeerId(peerId: string): string {
     return `.${peerId.substring(peerId.length - 4)}`;
 }
@@ -82,4 +84,26 @@ export function versionCompare(ref: string, version: string): Res.Result<VrsnCmp
 
 export function setDebugScope(scope: string) {
     debug.enable(scope);
+}
+
+export function setDebugScopeLevel(scope?: string, level?: string) {
+    const scp = scope ? scope : '*';
+    const lvl = debugLevel(level);
+    debug.enable([scp, lvl].join(','));
+}
+
+function debugLevel(level?: string) {
+    const lvl = level ? level : DefaultLogLevel;
+    switch (lvl.toLowerCase()) {
+        case 'error':
+            return '-*:warn,-*:info,-*:verbose';
+        case 'warn':
+            return '-*:info,-*:verbose';
+        case 'info':
+            return '-*:verbose';
+        case 'verbose':
+            return '';
+        default:
+            return debugLevel(DefaultLogLevel);
+    }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -78,7 +78,8 @@
         "FORCE_ZERO_HOP",
         "FORCE_MANUAL_RELAYING",
         "SEGMENT_LIMIT",
-        "FAILED_REQUESTS_FILE"
+        "FAILED_REQUESTS_FILE",
+        "DEBUG_LEVEL"
       ]
     },
     "@rpch/availability-monitor#build": {


### PR DESCRIPTION
Expose `DEBUG_LEVEL` in RPC server and allow debugLevel ops parameter in SDK.
This will set a minimal debug level and can be used in addition with scope to better control logging output.
SDK and RPC-Server now default to `info` log level.
Will only use default log level if `DEBUG` is not set.