### PR TITLE
Do not run chown on user specified volume after container start

### DIFF
--- a/.changeset/great-dingos-relate.md
+++ b/.changeset/great-dingos-relate.md
@@ -1,0 +1,5 @@
+---
+'@rpch/rpc-server': patch
+---
+
+make failed reqs volume mountable without using chown

--- a/apps/rpc-server/Dockerfile
+++ b/apps/rpc-server/Dockerfile
@@ -79,8 +79,7 @@ COPY apps/rpc-server/docker_files/service.d /etc/service.d
 COPY apps/rpc-server/docker_files/entrypoint.sh /
 
 # copied from postgres container
-# this 1777 will be replaced by 0700 at runtime (allows semi-arbitrary "--user" values)
-RUN mkdir -p /app/failed_reqs && chmod 1777 /app/failed_reqs
+RUN mkdir -p /app/failed_reqs && chown node:node /app/failed_reqs && chmod 1777 /app/failed_reqs
 VOLUME /app/failed_reqs
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/apps/rpc-server/Dockerfile
+++ b/apps/rpc-server/Dockerfile
@@ -59,8 +59,6 @@ RUN apk upgrade --no-cache && \
     mkdir -p /etc/certs && \
     addgroup -g 103 -S www && \
     adduser -u 103 -D -S -G www www && \
-    addgroup -g 104 -S node && \
-    adduser -u 104 -D -S -G node node && \
     chown -R www:www /etc/certs
 
 # copy over minimal fileset to run rpc-server
@@ -78,8 +76,7 @@ COPY apps/rpc-server/docker_files/haproxy.conf /etc/haproxy/haproxy.conf
 COPY apps/rpc-server/docker_files/service.d /etc/service.d
 COPY apps/rpc-server/docker_files/entrypoint.sh /
 
-# copied from postgres container
-RUN mkdir -p /app/failed_reqs && chown node:node /app/failed_reqs && chmod 1777 /app/failed_reqs
+RUN mkdir -p /app/failed_reqs
 VOLUME /app/failed_reqs
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/apps/rpc-server/Dockerfile
+++ b/apps/rpc-server/Dockerfile
@@ -78,6 +78,11 @@ COPY apps/rpc-server/docker_files/haproxy.conf /etc/haproxy/haproxy.conf
 COPY apps/rpc-server/docker_files/service.d /etc/service.d
 COPY apps/rpc-server/docker_files/entrypoint.sh /
 
+# copied from postgres container
+# this 1777 will be replaced by 0700 at runtime (allows semi-arbitrary "--user" values)
+RUN mkdir -p /app/failed_reqs && chmod 1777 /app/failed_reqs
+VOLUME /app/failed_reqs
+
 ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["start"]

--- a/apps/rpc-server/docker_files/entrypoint.sh
+++ b/apps/rpc-server/docker_files/entrypoint.sh
@@ -58,8 +58,5 @@ FRONTEND_HTTP_PORT=${FRONTEND_HTTP_PORT:-45750}
 FRONTEND_HTTPS_PORT=${FRONTEND_HTTPS_PORT:-45751}
 EOF
 
-# enable failed reqs dir and keep it writable
-mkdir -p /failed_reqs && chown node:node /failed_reqs
-
 ### Execute script with arguments
 exec "${@}"

--- a/apps/rpc-server/docker_files/service.d/rpc-server/run
+++ b/apps/rpc-server/docker_files/service.d/rpc-server/run
@@ -8,4 +8,4 @@ NOTICE "[RPC-SERVER] -- Starting Service rpc-server ..."
 # load docker env vars
 export $(grep -v '^#' /docker.env | xargs -0)
 
-exec chpst -u node /usr/bin/node /app/build/index.js 2>&1
+exec chpst -u root /usr/bin/node /app/build/index.js 2>&1


### PR DESCRIPTION
In order to avoid using chown after mounting a user volume run RPCh server with root permission inside container