### PR TITLE
Allow chainId reporting on quota tables

### DIFF
--- a/.changeset/mighty-cups-pay.md
+++ b/.changeset/mighty-cups-pay.md
@@ -1,0 +1,5 @@
+---
+'@rpch/sdk': minor
+---
+
+Report chainId for provider with request payload

--- a/.changeset/orange-kiwis-peel.md
+++ b/.changeset/orange-kiwis-peel.md
@@ -1,0 +1,5 @@
+---
+'@rpch/discovery-platform': minor
+---
+
+Allow chainId reporting

--- a/apps/discovery-platform/migrations/1712644546653_add-chain-id.js
+++ b/apps/discovery-platform/migrations/1712644546653_add-chain-id.js
@@ -1,0 +1,15 @@
+/* eslint-disable camelcase */
+
+exports.up = (pgm) => {
+    pgm.addColumn('request_quotas', {
+        chain_id: {
+            type: 'varchar(255)',
+        },
+    });
+
+    pgm.addColumn('response_quotas', {
+        chain_id: {
+            type: 'varchar(255)',
+        },
+    });
+};

--- a/apps/discovery-platform/package.json
+++ b/apps/discovery-platform/package.json
@@ -16,7 +16,7 @@
         "start": "node build/index.js"
     },
     "dependencies": {
-        "@rpch/sdk": "1.12.1",
+        "@rpch/sdk": "1.12.2",
         "@types/express-session": "^1.17.7",
         "@types/memory-cache": "^0.2.2",
         "@types/passport": "^1.0.12",

--- a/apps/discovery-platform/src/entry-server/routers/v1/quota.ts
+++ b/apps/discovery-platform/src/entry-server/routers/v1/quota.ts
@@ -31,6 +31,11 @@ export const schema: Record<keyof quota.Attrs & 'clientId', ParamSchema> = {
         toInt: true,
         optional: true,
     },
+    chainId: {
+        in: 'body',
+        isString: true,
+        optional: true,
+    },
 };
 
 export function request(dbPool: Pool) {

--- a/apps/discovery-platform/src/quota.ts
+++ b/apps/discovery-platform/src/quota.ts
@@ -4,27 +4,42 @@ export type Attrs = {
     rpcMethod?: string;
     segmentCount: number;
     lastSegmentLength?: number;
+    chainId?: string;
 };
 
 export function createRequest(dbPool: Pool, nodeId: string, clientId: string, attrs: Attrs) {
     const q = [
         'insert into request_quotas',
-        '(id, client_id, rpc_method, segment_count, reported_by_id, last_segment_length)',
-        'values (gen_random_uuid(), $1, $2, $3, $4, $5)',
+        '(id, client_id, rpc_method, segment_count, reported_by_id, last_segment_length, chain_id)',
+        'values (gen_random_uuid(), $1, $2, $3, $4, $5, $6)',
     ].join(' ');
 
-    const vals = [clientId, attrs.rpcMethod, attrs.segmentCount, nodeId, attrs.lastSegmentLength];
+    const vals = [
+        clientId,
+        attrs.rpcMethod,
+        attrs.segmentCount,
+        nodeId,
+        attrs.lastSegmentLength,
+        attrs.chainId,
+    ];
     return dbPool.query(q, vals);
 }
 
 export function createResponse(dbPool: Pool, nodeId: string, clientId: string, attrs: Attrs) {
     const q = [
         'insert into response_quotas',
-        '(id, client_id, rpc_method, segment_count, reported_by_id, last_segment_length)',
-        'values (gen_random_uuid(), $1, $2, $3, $4, $5)',
+        '(id, client_id, rpc_method, segment_count, reported_by_id, last_segment_length, chain_id)',
+        'values (gen_random_uuid(), $1, $2, $3, $4, $5, $6)',
     ].join(' ');
 
-    const vals = [clientId, attrs.rpcMethod, attrs.segmentCount, nodeId, attrs.lastSegmentLength];
+    const vals = [
+        clientId,
+        attrs.rpcMethod,
+        attrs.segmentCount,
+        nodeId,
+        attrs.lastSegmentLength,
+        attrs.chainId,
+    ];
     return dbPool.query(q, vals);
 }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -239,6 +239,7 @@ export default class SDK {
                 ? resNodes
                 : { reqRelayPeerId: undefined, respRelayPeerId: undefined };
             const id = RequestCache.generateId(this.requestCache);
+            const cId = this.chainIds.get(provider);
             const resReq = Request.create({
                 id,
                 provider,
@@ -253,6 +254,7 @@ export default class SDK {
                 hops: this.hops,
                 reqRelayPeerId,
                 respRelayPeerId,
+                chainId: cId,
             });
 
             if (Res.isErr(resReq)) {

--- a/packages/sdk/src/payload.ts
+++ b/packages/sdk/src/payload.ts
@@ -11,7 +11,7 @@ export type ReqPayload = {
     hops?: number; // defaults to 1
     relayPeerId?: string; // default to autorouting
     withDuration?: boolean; // request duration
-    chainId?: string;
+    chainId?: string; // provider chain id
 };
 
 export enum RespType {

--- a/packages/sdk/src/payload.ts
+++ b/packages/sdk/src/payload.ts
@@ -11,6 +11,7 @@ export type ReqPayload = {
     hops?: number; // defaults to 1
     relayPeerId?: string; // default to autorouting
     withDuration?: boolean; // request duration
+    chainId?: string;
 };
 
 export enum RespType {
@@ -57,7 +58,8 @@ type TransportReqPayload = {
     // dev/debug
     n?: number; // hops
     r?: string; // relayPeerId
-    w?: boolean; // wDur
+    w?: boolean; // withDuration
+    i?: string; // chainId
 };
 
 type TransportRespPayload =
@@ -169,6 +171,9 @@ function reqToTrans(r: ReqPayload): TransportReqPayload {
     if (r.withDuration) {
         t.w = r.withDuration;
     }
+    if (r.chainId) {
+        t.i = r.chainId;
+    }
     return t;
 }
 
@@ -232,6 +237,7 @@ function transToReq(t: TransportReqPayload): ReqPayload {
         hops: t.n,
         relayPeerId: t.r,
         withDuration: t.w,
+        chainId: t.i,
     };
 }
 

--- a/packages/sdk/src/request.ts
+++ b/packages/sdk/src/request.ts
@@ -45,6 +45,7 @@ export function create({
     hops,
     reqRelayPeerId,
     respRelayPeerId,
+    chainId,
 }: {
     id: string;
     originalId?: string;
@@ -60,6 +61,7 @@ export function create({
     hops?: number;
     reqRelayPeerId?: string;
     respRelayPeerId?: string;
+    chainId?: string;
 }): Res.Result<{ request: Request; session: compatCrypto.Session }> {
     const payload: Payload.ReqPayload = {
         endpoint: provider,
@@ -70,6 +72,7 @@ export function create({
         hops,
         relayPeerId: respRelayPeerId,
         withDuration: measureRPClatency,
+        chainId,
     };
     const resEncode = Payload.encodeReq(payload);
     if (Res.isErr(resEncode)) {

--- a/packages/sdk/src/request.ts
+++ b/packages/sdk/src/request.ts
@@ -20,6 +20,7 @@ export type Request = {
     hops?: number;
     reqRelayPeerId?: string;
     respRelayPeerId?: string;
+    chainId?: string;
 };
 
 export type UnboxRequest = {


### PR DESCRIPTION
If we have a chainId available, add it as part of the request payload.
Allow chainId reporting on quota tables.